### PR TITLE
backend: Use UTC for instance stats default time

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -646,7 +646,7 @@ func (api *API) instanceStatusHistoryQuery(instanceID, appID, groupID string, li
 // that have been checked in during a given duration from a given time.
 func (api *API) instanceStatsQuery(t *time.Time, duration *time.Duration) *goqu.SelectDataset {
 	if t == nil {
-		now := time.Now()
+		now := time.Now().UTC()
 		t = &now
 	}
 


### PR DESCRIPTION
The time.Now() function uses the local time which causes a mismatch and no entries get created when, e.g., being two hours ahead because the instance would be checking in at 10 UTC but it gets compared to 12 local time and in this time span nothing is able to check in because the local time will always be too far ahead.
Use the right time zone for the default time of the instance stats query.


## How to use


## Testing done

Checked whether entries get created:
```
psql postgres://postgres:nebraska@localhost:5432/nebraska -c "select * from instance_stats;"
```