### PR TITLE
backend: Change default interval for instance stats query

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -49,7 +49,7 @@ const (
 
 const (
 	validityInterval postgresDuration = "1 days"
-	defaultInterval  time.Duration    = time.Hour
+	defaultInterval  time.Duration    = 2 * time.Hour
 )
 
 // Instance represents an instance running one or more applications for which

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -137,11 +137,12 @@ func New(conf *config.Config, db *db.API) (*echo.Echo, error) {
 
 	// setup background job for updating instance stats
 	go func() {
-		err := db.UpdateInstanceStats(nil, nil)
+		// update once at startup
+		err = db.UpdateInstanceStats(nil, nil)
 		if err != nil {
 			logger.Err(err).Msg("Error updating instance stats")
 		}
-		ticker := time.NewTicker(db.GetDefaultInterval())
+		ticker := time.NewTicker(time.Hour)
 		defer ticker.Stop()
 
 		for range ticker.C {


### PR DESCRIPTION
Following #663 where we add the background job to periodically populate the `instance_stats` table, we want to ensure that we generate entries for instances that may not check in hourly but are still active. Thus, we consider a 2-hour default interval for instances checking in, maintaining the hourly cadence of the background job as desired.