### PR TITLE
docs: fix tipo of helm repo address

### DIFF
--- a/docs/authorization/_index.md
+++ b/docs/authorization/_index.md
@@ -290,7 +290,7 @@ To install the Helm Chart using the default configuration (noop authentication),
 you can execute:
 
 ```console
-$ helm repo add nebraska https://kinvolk.github.io/nebraska/
+$ helm repo add nebraska https://kinvolk.github.io/nebraska
 $ helm install my-nebraska nebraska/nebraska
 ```
 


### PR DESCRIPTION
# Docs: remove trailing slash of helm repo address

Remove trailing slash of helm repo address in the documentation, so the command won't fail.

## How to use

Execute the helm repo add command

## Testing done

Tested on Ubuntu 22.04.2 LTS with helm3 v3.10.1  

Original:  
```bash
~$ helm repo add nebraska https://kinvolk.github.io/nebraska/
Error: looks like "https://kinvolk.github.io/nebraska/" is not a valid chart repository or cannot be reached: failed to fetch https://kinvolk.github.io/nebraska/index.yaml : 404 Not Found
```
Fixed:  
```bash
~$ helm repo add nebraska https://flatcar.github.io/nebraska
"nebraska" has been added to your repositories
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
