### PR TITLE
chore: Update to alpine:3.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY frontend ./
 RUN npm run build
 
 # Final Docker image 
-FROM alpine:3.15.0
+FROM alpine:3.18.5
 
 RUN apk update && \
 	apk add ca-certificates tzdata


### PR DESCRIPTION
# Update base image to alpine 3.18

This change addresses two things:
- alpine 3.15 is EOL since november

  > ![Alpine Linux releases](https://github.com/flatcar/nebraska/assets/7290987/5ec9f832-f8e2-4542-8655-a1087477860f)

- security updates (HIGH: 14, CRITICAL: 1)

<details>
  <summary>Trivy results with alpine 3.15.0</summary>
  
  ```console
ghcr.io/kinvolk/nebraska:2.8.6 (alpine 3.15.0)

Total: 29 (UNKNOWN: 0, LOW: 0, MEDIUM: 14, HIGH: 14, CRITICAL: 1)

┌──────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├──────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox      │ CVE-2022-28391 │ HIGH     │ fixed  │ 1.34.1-r3         │ 1.34.1-r5     │ busybox: remote attackers may execute arbitrary code if     │
│              │                │          │        │                   │               │ netstat is used                                             │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-28391                  │
├──────────────┼────────────────┤          │        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-0778  │          │        │ 1.1.1l-r7         │ 1.1.1n-r0     │ openssl: Infinite loop in BN_mod_sqrt() reachable when      │
│              │                │          │        │                   │               │ parsing certificates                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-0778                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4450  │          │        │                   │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286  │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in   │
│              │                │          │        │                   │               │ verifying X509 policy...                                    │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│              ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │        │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │          │        │                   │ 1.1.1t-r0     │ openssl: timing attack in RSA Decryption implementation     │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2     │ openssl: Invalid certificate policies in leaf certificates  │
│              │                │          │        │                   │               │ are silently ignored                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0     │ openssl: Possible DoS translating ASN.1 object identifiers  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2     │ openssl: Excessive time spent checking DH keys and          │
│              │                │          │        │                   │               │ parameters                                                  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0     │ OpenSSL: Excessive time spent checking DH q parameter value │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1     │ openssl: Generating excessively long X9.42 DH keys or       │
│              │                │          │        │                   │               │ checking excessively long X9.42...                          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├──────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libretls     │ CVE-2022-0778  │ HIGH     │        │ 3.3.4-r2          │ 3.3.4-r3      │ openssl: Infinite loop in BN_mod_sqrt() reachable when      │
│              │                │          │        │                   │               │ parsing certificates                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-0778                   │
├──────────────┤                │          │        ├───────────────────┼───────────────┤                                                             │
│ libssl1.1    │                │          │        │ 1.1.1l-r7         │ 1.1.1n-r0     │                                                             │
│              │                │          │        │                   │               │                                                             │
│              │                │          │        │                   │               │                                                             │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4450  │          │        │                   │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286  │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in   │
│              │                │          │        │                   │               │ verifying X509 policy...                                    │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│              ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │        │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │          │        │                   │ 1.1.1t-r0     │ openssl: timing attack in RSA Decryption implementation     │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2     │ openssl: Invalid certificate policies in leaf certificates  │
│              │                │          │        │                   │               │ are silently ignored                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0     │ openssl: Possible DoS translating ASN.1 object identifiers  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2     │ openssl: Excessive time spent checking DH keys and          │
│              │                │          │        │                   │               │ parameters                                                  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0     │ OpenSSL: Excessive time spent checking DH q parameter value │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1     │ openssl: Generating excessively long X9.42 DH keys or       │
│              │                │          │        │                   │               │ checking excessively long X9.42...                          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├──────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client   │ CVE-2022-28391 │ HIGH     │        │ 1.34.1-r3         │ 1.34.1-r5     │ busybox: remote attackers may execute arbitrary code if     │
│              │                │          │        │                   │               │ netstat is used                                             │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-28391                  │
├──────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ zlib         │ CVE-2022-37434 │ CRITICAL │        │ 1.2.11-r3         │ 1.2.12-r2     │ zlib: heap-based buffer over-read and overflow in inflate() │
│              │                │          │        │                   │               │ in inflate.c via a...                                       │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-37434                  │
│              ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2018-25032 │ HIGH     │        │                   │ 1.2.12-r0     │ A flaw found in zlib when compressing (not decompressing)   │
│              │                │          │        │                   │               │ certain inputs                                              │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2018-25032                  │
└──────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

nebraska/nebraska (gobinary)

Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 2, CRITICAL: 0)

┌───────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│            Library            │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├───────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v3 │ GHSA-2c7c-3mj9-8fqh │ MEDIUM   │ fixed  │ v3.0.0            │ 3.0.1         │ Decryption of malicious PBES2 JWE objects can consume        │
│                               │                     │          │        │                   │               │ unbounded system resources                                   │
│                               │                     │          │        │                   │               │ https://github.com/advisories/GHSA-2c7c-3mj9-8fqh            │
├───────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net              │ CVE-2023-39325      │ HIGH     │        │ v0.8.0            │ 0.17.0        │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                               │                     │          │        │                   │               │ excessive work (CVE-2023-44487)                              │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│                               ├─────────────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                               │ CVE-2023-3978       │ MEDIUM   │        │                   │ 0.13.0        │ golang.org/x/net/html: Cross site scripting                  │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3978                    │
│                               ├─────────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                               │ CVE-2023-44487      │          │        │                   │ 0.17.0        │ HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable   │
│                               │                     │          │        │                   │               │ to a DDoS attack...                                          │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-44487                   │
├───────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/protobuf    │ CVE-2023-24535      │ HIGH     │        │ v1.29.0           │ 1.29.1        │ panic when parsing an incomplete number                      │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-24535                   │
└───────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
  ```
</details>


Trivy results with alpine 3.18.0:
  
  ```console
kicm/nebraska:update-alpine3.18 (alpine 3.18.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


nebraska/nebraska (gobinary)

Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 2, CRITICAL: 0)

┌───────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│            Library            │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├───────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v3 │ GHSA-2c7c-3mj9-8fqh │ MEDIUM   │ fixed  │ v3.0.0            │ 3.0.1         │ Decryption of malicious PBES2 JWE objects can consume        │
│                               │                     │          │        │                   │               │ unbounded system resources                                   │
│                               │                     │          │        │                   │               │ https://github.com/advisories/GHSA-2c7c-3mj9-8fqh            │
├───────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net              │ CVE-2023-39325      │ HIGH     │        │ v0.8.0            │ 0.17.0        │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                               │                     │          │        │                   │               │ excessive work (CVE-2023-44487)                              │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│                               ├─────────────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                               │ CVE-2023-3978       │ MEDIUM   │        │                   │ 0.13.0        │ golang.org/x/net/html: Cross site scripting                  │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3978                    │
│                               ├─────────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                               │ CVE-2023-44487      │          │        │                   │ 0.17.0        │ HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable   │
│                               │                     │          │        │                   │               │ to a DDoS attack...                                          │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-44487                   │
├───────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/protobuf    │ CVE-2023-24535      │ HIGH     │        │ v1.29.0           │ 1.29.1        │ panic when parsing an incomplete number                      │
│                               │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-24535                   │
└───────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
  ```

## How to use

nothing special

## Testing done

started the container image locally after building.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
