### PR TITLE
chore: Update all actions related to the helm chart

### DIFF
--- a/.github/workflows/helm-chart-lint-test.yaml
+++ b/.github/workflows/helm-chart-lint-test.yaml
@@ -6,41 +6,46 @@ on:
       - charts/**
       - '!charts/**/README.md'
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.4.0
+          version: v3.12.1
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --config .github/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config .github/ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config .github/ct.yaml

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -8,12 +8,17 @@ on:
       - charts/**
       - '!charts/**/README.md'
 
+permissions:
+  contents: read
+
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    permissions:
+      contents: write  # for helm/chart-releaser-action to push chart release and create a release
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
@@ -23,16 +28,16 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.4.0
+          version: v3.12.1
 
       - name: Add Helm repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
# Update all actions related to the helm chart

I contributed the helm chart (https://github.com/flatcar/nebraska/pull/330) and the actions almost 2,5+ years ago and now it is time to update all actions related to produce and test the helm chart.

As I also maintain the Argo helm project, most updates are validated against the settings used over there:
- Chart testing: https://github.com/argoproj/argo-helm/blob/main/.github/workflows/lint-and-test.yml
- Chart releasing: https://github.com/argoproj/argo-helm/blob/main/.github/workflows/publish.yml

## How to use

n/a

## Testing done

Tested both workflow updates in my fork repo:
- chart releasing: https://github.com/mkilchhofer/nebraska/actions/runs/7172293969
- chart testing: https://github.com/mkilchhofer/nebraska/actions/runs/7171035624

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
