### PR TITLE
dependabot: Add required config file

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,26 @@
+## Reference: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "monday"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+      day: "monday"
+
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "gomod"
+    directory: "/updater"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
The config file seems to be needed now. It's also useful to limit the PRs in-flight with "open-pull-requests-limit: 0" if we get too many PRs at once.

Suggested by @mkilchhofer
