### PR TITLE
chore: Update and pin all actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -16,12 +16,12 @@ jobs:
 
   build:
     name: Lint & Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
     - name: Set up Go 1.19
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: 1.19.x
       id: go

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   build:
     name: Build Container Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
     - name: Check out code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
In my last PR(s), I updated the helm specific actions:
- https://github.com/flatcar/nebraska/pull/675
- https://github.com/flatcar/nebraska/pull/697

Now since dependabot can also update the actions (https://github.com/flatcar/nebraska/pull/676 / https://github.com/flatcar/nebraska/pull/685), we can pin all other actions too.

## How to use

Dependabot will update the actions in the future. Example PR from my other maintainer work over there:
- https://github.com/argoproj/argo-helm/pull/2382

## Testing done

Tested all 3 actions "manually" in my forked repo with this PR here:
- https://github.com/mkilchhofer/nebraska/pull/26

> ![image](https://github.com/flatcar/nebraska/assets/7290987/2bf1e440-744e-452d-ba4f-725296d28d0f)

Detailed action logs:
- frontend: https://github.com/mkilchhofer/nebraska/actions/runs/7187152180/job/19574106736?pr=26
- backend: https://github.com/mkilchhofer/nebraska/actions/runs/7187152185/job/19574106741?pr=26
- container build: https://github.com/mkilchhofer/nebraska/actions/runs/7187152181/job/19574106706?pr=26