### PR TITLE
fix: Exclude helm chart tags from appVersion calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO111MODULE=on
 export GO111MODULE
 
-TAG := `git describe --tags --always`
+TAG := `git describe --tags --always --exclude 'nebraska-helm*'`
 SHELL = /bin/bash
 DOCKER_CMD ?= "docker"
 DOCKER_REPO ?= "ghcr.io/kinvolk"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,7 @@
 GO111MODULE=on
 export GO111MODULE
 
-TAG := `git describe --tags --always`
+TAG := `git describe --tags --always --exclude 'nebraska-helm*'`
 SHELL = /bin/bash
 DOCKER_CMD ?= "docker"
 DOCKER_REPO ?= "ghcr.io/kinvolk"


### PR DESCRIPTION
It seems that the versioning gets confused by the helm releases also produces git tags.

Before this change:
<img width="635" alt="image" src="https://github.com/flatcar/nebraska/assets/7290987/079a58c2-16c2-479a-bfad-a2c840531b9a">

After:
<img width="337" alt="image" src="https://github.com/flatcar/nebraska/assets/7290987/1fdac779-e539-4de2-91d5-9d16f5633f7b">


## How to use

`-`

## Testing done

See screenshots above

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
