### PR TITLE
fix: Get rid of the <nil> fields in all log outputs

### DIFF
--- a/backend/pkg/util/log.go
+++ b/backend/pkg/util/log.go
@@ -23,11 +23,14 @@ func NewLogger(logContext string) zerolog.Logger {
 	case "", logFormatPretty:
 		fallthrough
 	default:
-		writer = zerolog.ConsoleWriter{Out: os.Stderr}
+		writer = zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: zerolog.TimeFieldFormat,
+		}
 		unknownFormat = true
 	}
 
-	logger := zerolog.New(writer).Hook(
+	logger := zerolog.New(writer).With().Timestamp().Logger().Hook(
 		zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, message string) {
 			e.Str("context", logContext)
 		}))


### PR DESCRIPTION
Fixes #715 

# Before change (status quo)

## env NEBRASKA_LOG_FORMAT unset

```log
<nil> DBG Unknown format context=api logFormat=
<nil> DBG Unknown format context=nebraska logFormat=
<nil> DBG Unknown format context=auth logFormat=
<nil> DBG Unknown format context=omaha logFormat=
<nil> DBG Unknown format context=nebraska logFormat=
<nil> DBG Unknown format context=nebraska logFormat=
<nil> DBG Unknown format context=syncer logFormat=

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
```

## env NEBRASKA_LOG_FORMAT=pretty

```log
<nil> DBG Unknown format context=api logFormat=pretty
<nil> DBG Unknown format context=nebraska logFormat=pretty
<nil> DBG Unknown format context=auth logFormat=pretty
<nil> DBG Unknown format context=omaha logFormat=pretty
<nil> DBG Unknown format context=nebraska logFormat=pretty
<nil> DBG Unknown format context=nebraska logFormat=pretty
<nil> DBG Unknown format context=syncer logFormat=pretty

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
```

## env NEBRASKA_LOG_FORMAT=json

```log

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
{"level":"info","machineId":"aaaa671d61774703ac7be60715220baa","appID":"e96281a6-d1af-4bde-9a0a-97b76e56dc57","group":"5b810680-e36a-4879-b98a-4f989e80b899","event":"update complete.success","previousVersion":"","context":"omaha","message":"processEvent eventError 0"}
```

# After this change

## env NEBRASKA_LOG_FORMAT unset

```log
2024-01-21T10:57:30+01:00 DBG Unknown format context=api logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=nebraska logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=auth logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=omaha logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=nebraska logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=nebraska logFormat=
2024-01-21T10:57:30+01:00 DBG Unknown format context=syncer logFormat=

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
```

## env NEBRASKA_LOG_FORMAT=pretty

```log
2024-01-21T11:17:25+01:00 DBG Unknown format context=api logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=nebraska logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=auth logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=omaha logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=nebraska logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=nebraska logFormat=pretty
2024-01-21T11:17:25+01:00 DBG Unknown format context=syncer logFormat=pretty

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
2024-01-21T11:17:27+01:00 INF processEvent eventError 0 appID=e96281a6-d1af-4bde-9a0a-97b76e56dc57 context=omaha event="update complete.success" group=5b810680-e36a-4879-b98a-4f989e80b899 machineId=aaaa671d61774703ac7be60715220baa previousVersion=
```

## env NEBRASKA_LOG_FORMAT=json

```log

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.2
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8000
{"level":"info","machineId":"aaaa671d61774703ac7be60715220baa","appID":"e96281a6-d1af-4bde-9a0a-97b76e56dc57","group":"5b810680-e36a-4879-b98a-4f989e80b899","event":"update complete.success","previousVersion":"","time":"2024-01-21T10:58:28+01:00","context":"omaha","message":"processEvent eventError 0"}
```