### PR TITLE
.github: Add GitHub Action to release container image

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,0 +1,49 @@
+name: Build Container Image
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - 'staging'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: flatcar/nebraska
+
+jobs:
+  build:
+    name: Build Container Image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Get tag name
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=false
+        tags: |
+          type=ref,event=tag
+          type=match,pattern=\d.\d.\d,value=latest
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+    - name: Check out code
+      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+    - name: Login to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64/v8
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
When creating a release tag we want the image to be built and published
    as flatcar/nebraska with the version tag and also as 'latest' image when
    the tag is not the special 'staging' tag.
    The nebraska-helm chart is also released on the same repo, and thus we
    need to filter for strict semver tags.

## How to use

Maybe we need to iterate over this a bit more in the course of the new release until it publishes things correctly.
