### PR TITLE
Only Require OIDC Refresh Token If Access Token Expired

### DIFF
--- a/backend/pkg/auth/oidc.go
+++ b/backend/pkg/auth/oidc.go
@@ -155,17 +155,6 @@ func (oa *oidcAuth) ValidateToken(c echo.Context) error {
 		return nil
 	}
 
-	// If refresh token is not available in the session
-	// mark the request as unauthorized so that the session
-	// can be recreated with refresh_token
-	session := echosessions.GetSession(c)
-	refreshToken := session.Get("refresh_token")
-	if refreshToken == nil {
-		logger.Debug().Str("request_id", requestID).Msg("ValidateToken, Refresh token not found in session")
-		httpError(c, http.StatusUnauthorized)
-		return nil
-	}
-
 	_, err := oa.verifier.Verify(ctx, token)
 	if err != nil {
 		logger.Error().Str("request_id", requestID).AnErr("error", err).Msg("ValidateToken, Token verification error")
@@ -375,23 +364,22 @@ func (oa *oidcAuth) Authenticate(c echo.Context) (teamID string, replied bool) {
 		return "", true
 	}
 
-	// If refresh token is not available in the session
-	// mark the request as unauthorized so that the session
-	// can be recreated with refresh_token
-	session := echosessions.GetSession(c)
-	refreshToken := session.Get("refresh_token")
-	if refreshToken == nil {
-		logger.Debug().Str("request_id", requestID).Msg("Refresh token not found in session")
-		httpError(c, http.StatusUnauthorized)
-		return "", true
-	}
-
 	// Verify Token
 	tk, err := oa.verifier.Verify(ctx, token)
 	if err != nil {
 		// If token is expired, use the refresh_token to fetch a new token
 		// and set the new id_token in response header
 		if strings.Contains(err.Error(), "token is expired") {
+			// If refresh token is not available in the session
+			// mark the request as unauthorized so that the session
+			// can be recreated with refresh_token
+			session := echosessions.GetSession(c)
+			refreshToken := session.Get("refresh_token")
+			if refreshToken == nil {
+				logger.Debug().Str("request_id", requestID).Msg("Refresh token not found in session")
+				httpError(c, http.StatusUnauthorized)
+				return "", true
+			}
 			ts := oa.oauthConfig.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken.(string)})
 			newToken, err := ts.Token()
 			if err != nil {

--- a/backend/pkg/auth/oidc.go
+++ b/backend/pkg/auth/oidc.go
@@ -375,7 +375,7 @@ func (oa *oidcAuth) Authenticate(c echo.Context) (teamID string, replied bool) {
 			// can be recreated with refresh_token
 			session := echosessions.GetSession(c)
 			refreshToken := session.Get("refresh_token")
-			if refreshToken == nil {
+			if refreshToken == nil || refreshToken == "" {
 				logger.Debug().Str("request_id", requestID).Msg("Refresh token not found in session")
 				httpError(c, http.StatusUnauthorized)
 				return "", true


### PR DESCRIPTION
# Only Require OIDC Refresh Token If Access Token Expired
Change the refresh token behaviour so that the refresh token is only deemed necessary when the access token has expired. If it is not supplied but the access token has not expired then we will no longer fail validation.

## How to use
Gain an id_token and refresh_token from OIDC, supply only the id_token in the Bearer auth header to Nebraska. This will work, whereas previously it did not.

## Testing done
Used `dex` with an LDAP connector and local user authentication, with group support added (https://github.com/mjudeikis/dex/tree/mjudeikis/groups.support). Tested OIDC authentication in browser through Dex with LDAP user, confirmed working. Tested OIDC authentication in `curl` through Dex with local user, confirmed working. The `curl` commands were similar to:
```
curl -L -X POST 'http://localhost:5556/dex/token' \
-H 'Authorization: Basic REDACTED' \
-H 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'grant_type=password' \
--data-urlencode 'scope=openid profile groups offline_access' \
--data-urlencode 'username=REDACTED' \
--data-urlencode 'password=REDACTED'

curl -vvv -H 'Authorization: Bearer REDACTED' -H 'Content-Type: application/json' -X GET http://localhost:3000/api/apps
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
