### PR TITLE
backend: default oidc scopes list

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -129,7 +129,7 @@ func Parse() (*Config, error) {
 	f.String("oidc-admin-roles", "", "comma-separated list of accepted roles with admin access")
 	f.String("oidc-viewer-roles", "", "comma-separated list of accepted roles with viewer access")
 	f.String("oidc-roles-path", "roles", "json path in which the roles array is present in the id token")
-	f.String("oidc-scopes", "openid", "comma-separated list of scopes to be used in OIDC")
+	f.String("oidc-scopes", "openid,offline_access", "comma-separated list of scopes to be used in OIDC")
 	f.String("oidc-session-secret", "", fmt.Sprintf("Session secret used for authenticating sessions in cookies used for storing OIDC info , will be generated if none is passed; can be taken from %s env var too", oidcSessionAuthKeyEnvName))
 	f.String("oidc-session-crypt-key", "", fmt.Sprintf("Session key used for encrypting sessions in cookies used for storing OIDC info, will be generated if none is passed; can be taken from %s env var too", oidcSessionCryptKeyEnvName))
 	f.String("oidc-management-url", "", "OIDC management url for managing the account")

--- a/backend/test/auth/oidc/auth_test.go
+++ b/backend/test/auth/oidc/auth_test.go
@@ -37,7 +37,7 @@ var conf = &config.Config{
 	OidcAdminRoles:      "nebraska-admin",
 	OidcViewerRoles:     "nebraska-member",
 	OidcRolesPath:       "groups",
-	OidcScopes:          "openid,profile,email,groups",
+	OidcScopes:          "openid,offline_access,profile,email,groups",
 }
 
 func TestMain(m *testing.M) {

--- a/backend/test/auth/oidc/auth_test.go
+++ b/backend/test/auth/oidc/auth_test.go
@@ -37,7 +37,7 @@ var conf = &config.Config{
 	OidcAdminRoles:      "nebraska-admin",
 	OidcViewerRoles:     "nebraska-member",
 	OidcRolesPath:       "groups",
-	OidcScopes:          "openid,offline_access,profile,email,groups",
+	OidcScopes:          "openid,profile,email,groups",
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
# Fix default oidc scopes list

The backend expects refresh tokens, however they have to be requested for the token exchange with special scope

The Nebraska backend expects refresh tokens for the Nebraska use sessions with the Nebraska frontend, however the refresh token is not acquired with the default configuration as it has to be requested by using the special scope `offline_access`.

You can remove the `offline_access` scope overriding the default config with the flag `--oidc-scopes`, for example `--oidc-scopes openid`.

## How to use / How to test

1. Set up an IDP
2. use the oidc authentication method
3. ensure that the `offline_access` scope is provided along with `openid` when Nebraska initiates the authentication flow
4. ensure the idp issues refresh tokens
5. set the access token expiration to a low value to easily verify if the bakcend can obtain new access tokens with the refresh token
6. test the athorization flow after login and see if new access tokens are issued with the refresh token
7. test if new authorization is required if the refresh token is missing or expired

## Testing done

```sh
air --build.cmd "go build -o ./bin/nebraska ./cmd/nebraska/main.go" \
         --build.bin "./bin/nebraska" \
         --build.args_bin "\
     -http-log \
     -debug \
     --auth-mode oidc \
     --oidc-admin-roles nebraska_admin \
     --oidc-viewer-roles nebraska_member \
     --oidc-roles-path \"http://kinvolk\.io/roles\" \
     --oidc-client-id _redacted_ \
     --oidc-issuer-url https://_redacted_.com/ \
     --oidc-client-secret _redacted_ \
     -oidc-valid-redirect-urls http://localhost:3000/"
```

Testing done before trial account on Auth0 (see the docs how to set up Auth0 for Nebraska) and a locally running Nebraska instance.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.