### PR TITLE
CI: README: Add OpenSSF scorecard badge

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,0 +1,59 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - main
+  schedule:
+    # Daily
+    - cron: '30 1 * * *'
+
+# based on https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+        with:
+          sarif_file: results.sarif
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Nebraska is an update manager for [Flatcar Container Linux](https://www.flatcar.org/).
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/flatcar/nebraska/badge)](https://scorecard.dev/viewer/?uri=github.com/flatcar/nebraska)
+
 ## Overview
 
 Nebraska offers an easy way to monitor and manage the rollout of updates to applications that use


### PR DESCRIPTION
# Add OpenSSF scorecard badge

- CI: scorecard-analysis: Add config for OpenSSF scorecard
- README: Add OpenSSF scorecard badge

This is required for CNCF projects at the incubated stage.

Additionally, once merged it gives more code scanning results in the Security tab -> Code Scanning section on github.
https://github.com/flatcar/nebraska/security/code-scanning

## How to use

Once merged click on the badge in the README.

Note, `flatcar/nebraska` isn't already scanned by OpenSSF, so it does not have data for it yet. To get the data, the action will have to be run manually the first time, OR wait for the badge results to be updated once daily. The action is run daily via github action cron.


## Testing done

We use it in the headlamp/inspektor gadget repos, and it uses the OpenSSF template for the workflow.

