### PR TITLE
Fix/901 OIDC cookie http only

### DIFF
--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -10,8 +10,6 @@
 #
 # See docker-compose.pg-persist.yaml for more information on persistent storage.
 
-version: "3.9"
-
 services:
   postgres:
     image: postgres:12.9

--- a/backend/pkg/sessions/session.go
+++ b/backend/pkg/sessions/session.go
@@ -110,10 +110,10 @@ func (s *Session) Save(writer http.ResponseWriter) error {
 		value = encoded
 	}
 	cookie := &http.Cookie{
-		Name:   s.Name(),
-		Value:  value,
-		Path:   "/",
-		MaxAge: maxAge,
+		Name:     s.Name(),
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
 		HttpOnly: true,
 	}
 	http.SetCookie(writer, cookie)

--- a/backend/pkg/sessions/session.go
+++ b/backend/pkg/sessions/session.go
@@ -114,6 +114,7 @@ func (s *Session) Save(writer http.ResponseWriter) error {
 		Value:  value,
 		Path:   "/",
 		MaxAge: maxAge,
+		HttpOnly: true,
 	}
 	http.SetCookie(writer, cookie)
 	return nil

--- a/frontend/src/components/Channels/ChannelEdit.tsx
+++ b/frontend/src/components/Channels/ChannelEdit.tsx
@@ -233,7 +233,9 @@ export default function ChannelEdit(props: ChannelEditProps) {
               const selectedPackage = packages.packages
                 .filter((packageItem: Package) => packageItem.arch === arch)
                 .filter((packageItem: Package) => packageItem.version === packageVersion);
-              setFieldValue('package', selectedPackage[0].id);
+              if (selectedPackage.length) {
+                setFieldValue('package', selectedPackage[0].id);
+              }
             }}
             suggestions={packages.packages
               .filter((packageItem: Package) => packageItem.arch === arch)


### PR DESCRIPTION
# Make session cookie HTTP only

See: https://github.com/flatcar/nebraska/issues/901

## Testing done

Run the stack locally with oidc auth mode:
```sh
air --build.cmd "go build -o ./bin/nebraska ./cmd/nebraska/main.go" \
         --build.bin "./bin/nebraska" \
         --build.args_bin "\
     -debug \
     --auth-mode oidc \
     --oidc-admin-roles nebraska_admin \
     --oidc-viewer-roles nebraska_member \
     --oidc-roles-path \"http://kinvolk\.io/roles\" \
     --oidc-client-id [redacted]\
     --oidc-issuer-url https://[redacted].com/ \
     --oidc-client-secret [redacted] \
     -oidc-valid-redirect-urls http://localhost:3000/*"
```
Obeserve that the oidc cookie has the httponly flag after login:
![Screenshot 2025-02-06 093202](https://github.com/user-attachments/assets/cb6df88e-ed41-47ee-a446-20d19fda5d49)

