### PR TITLE
fix vunerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY frontend ./
 RUN npm run build
 
 # Final Docker image 
-FROM alpine:3.18.5
+FROM alpine:3.21.3
 
 RUN apk update && \
 	apk add ca-certificates tzdata


### PR DESCRIPTION
# Fix Vulnerabilties

upgraded alpine version from 3.18.5 to 3.21.3

## How to use
Before the change
``` (⎈|stg-ancient-snake:default)➜  nebraska git:(main) ✗ trivy image --scanners=vuln --vuln-type=os --severity=LOW,MEDIUM,HIGH,CRITICAL --ignore-unfixed testing/flatcar/nebraska:latest
2025-03-24T14:52:27+05:30       INFO    Vulnerability scanning is enabled
2025-03-24T14:52:27+05:30       INFO    Detected OS     family="alpine" version="3.18.5"
2025-03-24T14:52:27+05:30       INFO    [alpine] Detecting vulnerabilities...   os_version="3.18" repository="3.18" pkg_num=17
2025-03-24T14:52:27+05:30       WARN    Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

testing/flatcar/nebraska:latest (alpine 3.18.5)

Total: 32 (LOW: 4, MEDIUM: 28, HIGH: 0, CRITICAL: 0)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2023-42363 │ MEDIUM   │ fixed  │ 1.36.1-r5         │ 1.36.1-r7     │ busybox: use-after-free in awk                              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                  │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                  │
├───────────────┼────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox-binsh │ CVE-2023-42363 │          │        │                   │ 1.36.1-r7     │ busybox: use-after-free in awk                              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                  │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                  │
├───────────────┼────────────────┤          │        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2023-6129  │          │        │ 3.1.4-r1          │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector        │
│               │                │          │        │                   │               │ registers on PowerPC                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6237  │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public   │
│               │                │          │        │                   │               │ keys                                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-0727  │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-13176 │          │        │                   │ 3.1.8-r0      │ openssl: Timing side-channel in ECDSA signature computation │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-4603  │          │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and         │
│               │                │          │        │                   │               │ parameters                                                  │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-4741  │          │        │                   │ 3.1.6-r0      │ openssl: Use After Free with SSL_free_buffers               │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741                   │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-5535  │          │        │                   │               │ openssl: SSL_select_next_proto buffer overread              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-6119  │          │        │                   │ 3.1.7-r0      │ openssl: Possible denial of service in X.509 name checks    │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6119                   │
│               ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in   │
│               │                │          │        │                   │               │ TLSv1.3                                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-9143  │          │        │                   │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│               │                │          │        │                   │               │ memory access                                               │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2023-6129  │ MEDIUM   │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector        │
│               │                │          │        │                   │               │ registers on PowerPC                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6237  │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public   │
│               │                │          │        │                   │               │ keys                                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-0727  │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-13176 │          │        │                   │ 3.1.8-r0      │ openssl: Timing side-channel in ECDSA signature computation │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-4603  │          │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and         │
│               │                │          │        │                   │               │ parameters                                                  │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-4741  │          │        │                   │ 3.1.6-r0      │ openssl: Use After Free with SSL_free_buffers               │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741                   │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-5535  │          │        │                   │               │ openssl: SSL_select_next_proto buffer overread              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-6119  │          │        │                   │ 3.1.7-r0      │ openssl: Possible denial of service in X.509 name checks    │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6119                   │
│               ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in   │
│               │                │          │        │                   │               │ TLSv1.3                                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-9143  │          │        │                   │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│               │                │          │        │                   │               │ memory access                                               │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2023-42363 │ MEDIUM   │        │ 1.36.1-r5         │ 1.36.1-r7     │ busybox: use-after-free in awk                              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                  │
│               ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                     │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                  │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                  │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```
After the change 

```(⎈|stg-ancient-snake:default)➜  nebraska git:(main) ✗ trivy image --scanners=vuln --vuln-type=os --severity=LOW,MEDIUM,HIGH,CRITICAL --ignore-unfixed testing/flatcar/nebraska:latest
2025-03-24T14:53:46+05:30       INFO    Vulnerability scanning is enabled
2025-03-24T14:53:46+05:30       INFO    Detected OS     family="alpine" version="3.21.3"
2025-03-24T14:53:46+05:30       WARN    This OS version is not on the EOL list  family="alpine" version="3.21"
2025-03-24T14:53:46+05:30       INFO    [alpine] Detecting vulnerabilities...   os_version="3.21" repository="3.21" pkg_num=17

testing/flatcar/nebraska:latest (alpine 3.21.3)

Total: 0 (LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```


## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
