### PR TITLE
release(helm): bump app to v2.10.0 and charts to v1.3.0 charts

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,8 +19,8 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 1.2.0
-appVersion: "2.9.0"
+version: 1.3.0
+appVersion: "2.10.0"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
# Release new helm charts version for Nebraska v2.10.0

https://github.com/flatcar/nebraska/releases/tag/2.10.0
