### PR TITLE
add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Flatcar Nebraska Security
+
+Instructions on interacting with the Flatcar Security Team can be found in the main Flatcar repository [here](https://github.com/flatcar/Flatcar/blob/main/SECURITY.md).
+
+For any immediate concerns, please contact the security team via [security@flatcar-linux.org](mailto:security@flatcar-linux.org). 


### PR DESCRIPTION
# Add SECURITY.md file

To improve the OSSF score for this repository, we can add a `SECURITY.md` file which points to the instructions in the main `flatcar/flatcar` repository. This feels like a better options than copying the file directly and then it becoming out of date. Also leaves a note on how to reach out to the security team with any immediate concerns to avoid adding hurdles for reaching out to the security team (because sometimes one extra link is just too far).

## How to use

N/A. Just documentation.

## Testing done

Look at the markdown file to ensure it makes sense and renders appropriately.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.