### PR TITLE
docs: add link to learn more about omaha protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Nebraska is an update manager for [Flatcar Container Linux](https://www.flatcar.
 
 Nebraska offers an easy way to monitor and manage the rollout of updates to applications that use
 the [Omaha](https://code.google.com/p/omaha/) protocol, with special functionality for Flatcar Container Linux updates.
+To learn more about the Omaha protocol, please refer to the upstream docs [here](https://github.com/google/omaha/blob/main/doc/ServerProtocolV2.md)
 
 ## Features
 


### PR DESCRIPTION
# Add link to learn more about Omaha protocol

There's already a link off to the upstream Omaha project itself. This adds a link directly to the protocol docs themselves (specifically v2, which I believe is what https://github.com/flatcar/go-omaha makes use of). This will allow users to learn more about the specifics of the protocol if they are interested.

## How to use

N/A. Documentation update.

## Testing done

Read the docs to ensure they make sense.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

resolves #267 