### PR TITLE
backend: update go-omaha

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,11 +1,14 @@
 module github.com/flatcar/nebraska/backend
 
-go 1.23.0
+go 1.24
+
+toolchain go1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/doug-martin/goqu/v9 v9.19.0
+	github.com/flatcar/go-omaha v0.0.2-0.20250627105643-c9009b394616
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/golangci/golangci-lint/v2 v2.2.1
 	github.com/google/go-github/v28 v28.1.1
@@ -15,7 +18,6 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kevinburke/go-bindata v3.24.0+incompatible
-	github.com/kinvolk/go-omaha v0.0.2-0.20221206142015-1518a03b832b
 	github.com/knadh/koanf v1.5.0
 	github.com/labstack/echo-contrib v0.17.4
 	github.com/labstack/echo/v4 v4.13.4

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -176,6 +176,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/firefart/nonamedreturns v1.0.6 h1:vmiBcKV/3EqKY3ZiPxCINmpS431OcE1S47AQUwhrg8E=
 github.com/firefart/nonamedreturns v1.0.6/go.mod h1:R8NisJnSIpvPWheCq0mNRXJok6D8h7fagJTF8EMEwCo=
+github.com/flatcar/go-omaha v0.0.2-0.20250627105643-c9009b394616 h1:GoRpDC9BhywYEagH2R+8q1eohih9u6ndXSGXvvSaSlI=
+github.com/flatcar/go-omaha v0.0.2-0.20250627105643-c9009b394616/go.mod h1:ntSHoD5lo8beYqjwPd98MPFaVOFtQ7ezRcnvMvnPwkw=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -320,7 +322,6 @@ github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+H
 github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gordonklaus/ineffassign v0.1.0 h1:y2Gd/9I7MdY1oEIt+n+rowjBNDcLQq3RsH5hwJd0f9s=
@@ -469,8 +470,6 @@ github.com/karamaru-alpha/copyloopvar v1.2.1 h1:wmZaZYIjnJ0b5UoKDjUHrikcV0zuPyyx
 github.com/karamaru-alpha/copyloopvar v1.2.1/go.mod h1:nFmMlFNlClC2BPvNaHMdkirmTJxVCY0lhxBtlfOypMM=
 github.com/kevinburke/go-bindata v3.24.0+incompatible h1:qajFA3D0pH94OTLU4zcCCKCDgR+Zr2cZK/RPJHDdFoY=
 github.com/kevinburke/go-bindata v3.24.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
-github.com/kinvolk/go-omaha v0.0.2-0.20221206142015-1518a03b832b h1:+D/yo45hVrp5qdcifcHzQAcRWRXIOpxZpk0BW2Z4G1w=
-github.com/kinvolk/go-omaha v0.0.2-0.20221206142015-1518a03b832b/go.mod h1:SAEkKv9dpmCAVA3KxGdlHMoO4VaCAfIZuui57PqGQbg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.9.0 h1:9xt1zI9EBfcYBvdU1nVrzMzzUPUtPKs9bVSIM3TAb3M=
 github.com/kisielk/errcheck v1.9.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi0D+/VL/i8=

--- a/backend/pkg/omaha/omaha.go
+++ b/backend/pkg/omaha/omaha.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strconv"
 
-	omahaSpec "github.com/kinvolk/go-omaha/omaha"
+	omahaSpec "github.com/flatcar/go-omaha/omaha"
 	"github.com/rs/zerolog"
 
 	"github.com/flatcar/nebraska/backend/pkg/api"

--- a/backend/pkg/omaha/omaha_test.go
+++ b/backend/pkg/omaha/omaha_test.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	omahaSpec "github.com/kinvolk/go-omaha/omaha"
+	omahaSpec "github.com/flatcar/go-omaha/omaha"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"

--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flatcar/go-omaha/omaha"
 	"github.com/google/uuid"
-	"github.com/kinvolk/go-omaha/omaha"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/flatcar/nebraska/backend/pkg/api"

--- a/backend/pkg/syncer/syncer_test.go
+++ b/backend/pkg/syncer/syncer_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"

--- a/backend/test/api/api_secret_test.go
+++ b/backend/test/api/api_secret_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flatcar/go-omaha/omaha"
 	"github.com/google/uuid"
 	"github.com/jinzhu/copier"
-	"github.com/kinvolk/go-omaha/omaha"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/backend/test/api/omaha_test.go
+++ b/backend/test/api/omaha_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flatcar/go-omaha/omaha"
 	"github.com/google/uuid"
-	"github.com/kinvolk/go-omaha/omaha"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
# Update go-omaha references to Flatcar

Recently the `go-omaha` library was updated from `github.com/kinvolk` -> `github.com/flatcar`. This updates the remaining references in the `backend` module to use the updated repo references.

## How to use

No library changes. Just updating to use the new module reference

## Testing done

`make backend`

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
