### PR TITLE
ossf: pin remaining gha dependencies

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
         make ci
       working-directory: frontend
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Get tag name
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         flavor: |
@@ -35,13 +35,13 @@ jobs:
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Login to registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: .
         push: true


### PR DESCRIPTION
# Pin remaining GHA third party dependencies

After taking a look at the OSSF scorecard, there appeared to be a handful of third party GHA dependencies that weren't pinned. Since a majority of the workflows already pin the dependencies, it makes sense to pin the remaining once to standardize things (and also increase the rating of the scorecard).

## How to use

Ensure tests pass with the pinned dependencies in place

## Testing done
N/A

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.