### PR TITLE
Fix delete failures updating UI

### DIFF
--- a/frontend/src/__tests__/Api/api.spec.js
+++ b/frontend/src/__tests__/Api/api.spec.js
@@ -163,4 +163,28 @@ describe('API methods using URLSearchParams', () => {
       }
     );
   });
+
+  describe('deleteApplication', () => {
+    let deleteFetchMock;
+
+    beforeEach(() => {
+      deleteFetchMock = vi.spyOn(global, 'fetch');
+    });
+
+    it('should throw when the response is not ok', async () => {
+      deleteFetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      });
+
+      await expect(API.deleteApplication(applicationID)).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('should resolve when the response is ok', async () => {
+      const response = { ok: true, status: 204 };
+      deleteFetchMock.mockResolvedValueOnce(response);
+
+      await expect(API.deleteApplication(applicationID)).resolves.toBe(response);
+    });
+  });
 });

--- a/frontend/src/__tests__/stores/ApplicationsStore.delete.spec.ts
+++ b/frontend/src/__tests__/stores/ApplicationsStore.delete.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import API from '../../api/API';
+import ApplicationsStore from '../../stores/ApplicationsStore';
+
+describe('ApplicationsStore delete handling', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  it('does not remove an application when delete fails', async () => {
+    vi.spyOn(API, 'deleteApplication').mockRejectedValue({ status: 403 });
+
+    const store = new ApplicationsStore();
+    store.applications = [{ id: 'app-1', name: 'Test' }];
+    const emitSpy = vi.spyOn(store, 'emitChange');
+
+    store.deleteApplication('app-1');
+
+    await vi.waitFor(() => {
+      expect(store.applications).toHaveLength(1);
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(window.alert).toHaveBeenCalled();
+    });
+  });
+
+  it('does not remove a group when delete fails', async () => {
+    vi.spyOn(API, 'deleteGroup').mockRejectedValue({ status: 500 });
+
+    const store = new ApplicationsStore();
+    store.applications = [
+      {
+        id: 'app-1',
+        name: 'Test',
+        groups: [{ id: 'group-1', application_id: 'app-1', name: 'Group' }],
+      },
+    ];
+    const emitSpy = vi.spyOn(store, 'emitChange');
+
+    store.deleteGroup('app-1', 'group-1');
+
+    await vi.waitFor(() => {
+      expect(store.applications[0].groups).toHaveLength(1);
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(window.alert).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/api/API.ts
+++ b/frontend/src/api/API.ts
@@ -340,36 +340,27 @@ export default class API {
       'Content-Type': 'application/json',
       ...authHeaders,
     };
-    let fetchConfigObject: {
+    const fetchConfigObject: {
       method: string;
       body?: REQUEST_DATA_TYPE;
       headers?: {
         [prop: string]: any;
       };
     } = {
-      method: 'GET',
+      method,
       headers,
     };
 
-    if (method === 'DELETE') {
-      fetchConfigObject = {
-        method,
-        headers,
-      };
-      return fetch(url, fetchConfigObject);
-    } else {
-      if (method !== 'GET') {
-        fetchConfigObject = {
-          method,
-          headers,
-          body: data,
-        };
-      }
+    if (method !== 'GET' && method !== 'DELETE') {
+      fetchConfigObject.body = data;
     }
 
     return fetch(url, fetchConfigObject).then(response => {
       if (!response.ok) {
         throw response;
+      }
+      if (method === 'DELETE') {
+        return response;
       }
       return response.json();
     });

--- a/frontend/src/stores/ApplicationsStore.ts
+++ b/frontend/src/stores/ApplicationsStore.ts
@@ -2,6 +2,7 @@ import _ from 'underscore';
 
 import API from '../api/API';
 import { Application, Channel, Group, Package, Packages } from '../api/apiDataTypes';
+import i18n from '../i18n/config';
 import Store from './BaseStore';
 import { setUser } from './redux/features/user';
 import store from './redux/store';
@@ -160,13 +161,17 @@ class ApplicationsStore extends Store {
   }
 
   deleteApplication(applicationID: string) {
-    API.deleteApplication(applicationID).then(() => {
-      this.applications = _.without(
-        this.applications as _.List<any>,
-        _.findWhere(this.applications as _.Collection<any>, { id: applicationID })
-      );
-      this.emitChange();
-    });
+    API.deleteApplication(applicationID)
+      .then(() => {
+        this.applications = _.without(
+          this.applications as _.List<any>,
+          _.findWhere(this.applications as _.Collection<any>, { id: applicationID })
+        );
+        this.emitChange();
+      })
+      .catch(() => {
+        window.alert(i18n.t('common|generic_error'));
+      });
   }
 
   // Groups
@@ -186,18 +191,22 @@ class ApplicationsStore extends Store {
   }
 
   deleteGroup(applicationID: string, groupID: string) {
-    API.deleteGroup(applicationID, groupID).then(() => {
-      const applicationToUpdate = _.findWhere(this.applications as _.Collection<any>, {
-        id: applicationID,
-      });
-      const newGroups = _.without(
-        applicationToUpdate.groups,
-        _.findWhere(applicationToUpdate.groups, { id: groupID })
-      );
+    API.deleteGroup(applicationID, groupID)
+      .then(() => {
+        const applicationToUpdate = _.findWhere(this.applications as _.Collection<any>, {
+          id: applicationID,
+        });
+        const newGroups = _.without(
+          applicationToUpdate.groups,
+          _.findWhere(applicationToUpdate.groups, { id: groupID })
+        );
 
-      applicationToUpdate.groups = [...newGroups];
-      this.emitChange();
-    });
+        applicationToUpdate.groups = [...newGroups];
+        this.emitChange();
+      })
+      .catch(() => {
+        window.alert(i18n.t('common|generic_error'));
+      });
   }
 
   async updateGroup(data: Group) {


### PR DESCRIPTION

Fixes: #1433

Deleting an app or group looked like it worked even when the server said no. The UI removed the item, showed nothing wrong, and a refresh brought it back. That happened because DELETE requests skipped the same error check as every other API call, and the store always cleared local state when the promise resolved.

This PR checks `response.ok` for DELETE in `API.doRequest` and adds error handling in `deleteApplication` and `deleteGroup` so the list only updates after a successful response. If the server returns 403 or 500 the item stays put and the user gets a generic error alert.

## How to use

Pull the branch and run the frontend against a backend where you can trigger a failed delete. Easiest option is to open DevTools, paste a fetch override that returns 403 for DELETE requests, then delete an app or group from the menu. The item should stay in the list and you should see the error dialog. Refresh and confirm it is still there.

You can also test with a viewer account on an OIDC setup if you have one. DELETE should be denied by the API and the UI should behave the same way.

Run the unit tests with:

```
cd frontend
npx cross-env TEST_TZ=true npx vitest run src/__tests__/Api/api.spec.js src/__tests__/stores/ApplicationsStore.delete.spec.ts
```

All 18 tests should pass.

## Testing done

Ran the vitest command above locally. Output:

```
Test Files  2 passed (2)
     Tests  18 passed (18)
```

The new API tests confirm DELETE throws on 403 and resolves on success. The store tests confirm the app and group are not removed from cache when delete fails and that the error alert is shown.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
