### PR TITLE
Fix instance rename cancel triggering unnecessary refetch.

### DIFF
--- a/frontend/src/__tests__/Instances/Details.spec.tsx
+++ b/frontend/src/__tests__/Instances/Details.spec.tsx
@@ -1,0 +1,122 @@
+import '../../i18n/config.ts';
+
+import { ThemeProvider } from '@mui/material/styles';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import API from '../../api/API';
+import { Application, Group, Instance } from '../../api/apiDataTypes';
+import DetailsView from '../../components/Instances/Details';
+import themes from '../../lib/themes';
+
+function renderDetails(onInstanceUpdated = vi.fn()) {
+  const application = {
+    id: 'app-1',
+    name: 'Test App',
+  } as Application;
+
+  const group = {
+    id: 'group-1',
+    name: 'Test Group',
+    channel: null,
+  } as unknown as Group;
+
+  const instance = {
+    id: 'instance-1',
+    alias: '',
+    ip: '10.0.0.1',
+    application: {
+      instance_id: 'instance-1',
+      application_id: 'app-1',
+      group_id: 'group-1',
+      version: '1.0.0',
+      status: 3,
+      last_check_for_updates: '2024-01-01T00:00:00Z',
+    },
+    statusInfo: {
+      type: 'complete',
+      bgColor: '#000',
+      textColor: '#fff',
+      explanation: 'Up to date',
+    },
+  } as Instance;
+
+  return {
+    onInstanceUpdated,
+    ...render(
+      <BrowserRouter>
+        <ThemeProvider theme={themes['light']}>
+          <DetailsView
+            application={application}
+            group={group}
+            instance={instance}
+            onInstanceUpdated={onInstanceUpdated}
+          />
+        </ThemeProvider>
+      </BrowserRouter>
+    ),
+  };
+}
+
+async function openEditDialog() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('more-menu-open-button'));
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('Rename'));
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('instance-edit-form')).toBeTruthy();
+  });
+}
+
+describe('DetailsView edit dialog', () => {
+  beforeEach(() => {
+    vi.spyOn(API, 'getInstanceStatusHistory').mockResolvedValue([]);
+  });
+
+  it('does not refetch instance data when edit is canceled', async () => {
+    const onInstanceUpdated = vi.fn();
+    renderDetails(onInstanceUpdated);
+
+    await openEditDialog();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Cancel'));
+    });
+
+    expect(onInstanceUpdated).not.toHaveBeenCalled();
+  });
+
+  it('refetches instance data after a successful save', async () => {
+    const updatedInstance = {
+      id: 'instance-1',
+      alias: 'renamed-instance',
+    } as Instance;
+
+    vi.spyOn(API, 'updateInstance').mockResolvedValue(updatedInstance);
+
+    const onInstanceUpdated = vi.fn();
+    renderDetails(onInstanceUpdated);
+
+    await openEditDialog();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'renamed-instance' },
+      });
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() => {
+      expect(onInstanceUpdated).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/Instances/Details.tsx
+++ b/frontend/src/components/Instances/Details.tsx
@@ -327,7 +327,7 @@ function DetailsView(props: DetailsViewProps) {
 
   function onEditHide(newInstance?: Instance) {
     setShowEdit(false);
-    if (newInstance !== null) {
+    if (newInstance !== undefined) {
       onInstanceUpdated();
     }
   }


### PR DESCRIPTION
Fixes #1441

On the instance details page, opening the rename dialog and hitting Cancel still triggered a refetch even though nothing was saved. Cancel calls `onHide()` with no argument, so `newInstance` comes through as `undefined`. The check was `newInstance !== null`, and since `undefined !== null` is true, `onInstanceUpdated()` ran anyway.

The fix changes that check to `newInstance !== undefined`. Cancel closes the dialog and stops there. Save still passes the updated instance back and refetches as before.

A test was added in `frontend/src/__tests__/Instances/Details.spec.tsx` covering both paths — cancel should not refetch, save should.

## How to use

Pull the branch and open any instance details page. Click the menu, choose Rename, then Cancel without changing anything. The dialog should close and you should not see a fresh `GET` for that instance in the network tab.

To confirm save still works, open Rename again, change the alias, hit Save, and check that the page updates with the new name.

Run the unit tests with:

```
cd frontend
npx cross-env TEST_TZ=true npx vitest run src/__tests__/Instances/Details.spec.tsx
```

Both tests should pass.

## Testing done

Ran the vitest command above locally. Output:

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

The cancel test confirms `onInstanceUpdated` is not called when the dialog is dismissed. The save test confirms it is called once after a successful update.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
