### PR TITLE
fix(api): serialize empty read results as [] instead of null

### DIFF
--- a/backend/pkg/api/empty_slice_json_test.go
+++ b/backend/pkg/api/empty_slice_json_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/types"
+)
+
+func assertMarshalsToEmptyArray(t *testing.T, name string, v interface{}) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b), "%s must serialize to [] and not null", name)
+}
+
+func TestEmptyResultsSerializeToEmptyArray(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	tTeam, err := as.AddTeam(&types.Team{Name: "test_team_empty_slice"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&types.Application{Name: "test_app_empty_slice", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tChannel, err := as.AddChannel(&types.Channel{Name: "test_channel_empty_slice", Color: "blue", ApplicationID: tApp.ID, Arch: types.ArchAMD64})
+	require.NoError(t, err)
+	tGroup, err := as.AddGroup(&types.Group{
+		Name:                      "test_group_empty_slice",
+		ApplicationID:             tApp.ID,
+		ChannelID:                 null.StringFrom(tChannel.ID),
+		PolicyUpdatesEnabled:      true,
+		PolicySafeMode:            true,
+		PolicyPeriodInterval:      "15 minutes",
+		PolicyMaxUpdatesPerPeriod: 2,
+		PolicyUpdateTimeout:       "60 minutes",
+	})
+	require.NoError(t, err)
+	tPkg, err := as.AddPackage(&types.Package{
+		Type:          types.PkgTypeOther,
+		URL:           "http://sample.url/pkg",
+		Version:       "1.0.0",
+		ApplicationID: tApp.ID,
+		Arch:          types.ArchAMD64,
+	})
+	require.NoError(t, err)
+
+	t.Run("group version breakdown", func(t *testing.T) {
+		got, err := a.GetGroupVersionBreakdown(tGroup.ID)
+		require.NoError(t, err)
+		assertMarshalsToEmptyArray(t, "version breakdown", got)
+	})
+
+	t.Run("instance status history", func(t *testing.T) {
+		got, err := a.GetInstanceStatusHistory(uuid.New().String(), tApp.ID, tGroup.ID, 20)
+		require.NoError(t, err)
+		assertMarshalsToEmptyArray(t, "instance status history", got)
+	})
+
+	t.Run("activity", func(t *testing.T) {
+		got, err := a.GetActivity(uuid.New().String(), types.ActivityQueryParams{})
+		require.NoError(t, err)
+		assertMarshalsToEmptyArray(t, "activity", got)
+	})
+
+	t.Run("package floor channels", func(t *testing.T) {
+		got, err := a.GetPackageFloorChannels(tPkg.ID)
+		require.NoError(t, err)
+		assertMarshalsToEmptyArray(t, "package floor channels", got)
+	})
+
+	t.Run("package extra files", func(t *testing.T) {
+		got, err := a.GetPackage(tPkg.ID)
+		require.NoError(t, err)
+		assertMarshalsToEmptyArray(t, "package extra files", got.ExtraFiles)
+	})
+}

--- a/backend/pkg/api/internal/dbreads/activity.go
+++ b/backend/pkg/api/internal/dbreads/activity.go
@@ -19,7 +19,7 @@ func (q *Queries) GetActivityCount(teamID string, p types.ActivityQueryParams) (
 // GetActivity returns a list of activity entries that match the specified
 // criteria in the query parameters.
 func (q *Queries) GetActivity(teamID string, p types.ActivityQueryParams) ([]*types.Activity, error) {
-	var activityEntries []*types.Activity
+	activityEntries := []*types.Activity{}
 	query, _, err := q.activityQuery(teamID, p, false).ToSQL()
 	if err != nil {
 		return nil, err

--- a/backend/pkg/api/internal/dbreads/applications.go
+++ b/backend/pkg/api/internal/dbreads/applications.go
@@ -65,7 +65,7 @@ func (q *Queries) GetAppsCount(teamID string) (int, error) {
 // GetApps returns all applications that belong to the team id provided.
 func (q *Queries) GetApps(teamID string, page, perPage uint64) ([]*types.Application, error) {
 	page, perPage = validatePaginationParams(page, perPage)
-	var apps []*types.Application
+	apps := []*types.Application{}
 	limit, offset := sqlPaginate(page, perPage)
 	query, _, err := q.appsQuery().
 		Where(goqu.C("team_id").Eq(teamID)).

--- a/backend/pkg/api/internal/dbreads/channels.go
+++ b/backend/pkg/api/internal/dbreads/channels.go
@@ -66,7 +66,7 @@ func (q *Queries) getChannels(appID string) ([]*types.Channel, error) {
 }
 
 func (q *Queries) getChannelsFromQuery(query string) ([]*types.Channel, error) {
-	var channels []*types.Channel
+	channels := []*types.Channel{}
 	rows, err := q.db.Queryx(query)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/api/internal/dbreads/groups.go
+++ b/backend/pkg/api/internal/dbreads/groups.go
@@ -200,7 +200,7 @@ func (q *Queries) getGroups(appID string) ([]*types.Group, error) {
 }
 
 func (q *Queries) getGroupsFromQuery(query string) ([]*types.Group, error) {
-	var groups []*types.Group
+	groups := []*types.Group{}
 	rows, err := q.db.Queryx(query)
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (q *Queries) groupsQuery() *goqu.SelectDataset {
 
 // GetGroupVersionBreakdown returns a version breakdown of all instances running on a given group.
 func (q *Queries) GetGroupVersionBreakdown(groupID string) ([]*types.VersionBreakdownEntry, error) {
-	var entryList []*types.VersionBreakdownEntry
+	entryList := []*types.VersionBreakdownEntry{}
 
 	semverExpr, err := semverToIntArray("version")
 	if err != nil {

--- a/backend/pkg/api/internal/dbreads/instances.go
+++ b/backend/pkg/api/internal/dbreads/instances.go
@@ -104,7 +104,7 @@ func (q *Queries) getInstanceApp(appID, instanceID string, duration postgresDura
 // GetInstanceStatusHistory returns the status history of an instance in the
 // context of the application/group provided.
 func (q *Queries) GetInstanceStatusHistory(instanceID, appID, groupID string, limit uint64) ([]*types.InstanceStatusHistoryEntry, error) {
-	var instanceStatusHistory []*types.InstanceStatusHistoryEntry
+	instanceStatusHistory := []*types.InstanceStatusHistoryEntry{}
 	query, _, err := q.instanceStatusHistoryQuery(instanceID, appID, groupID, limit).ToSQL()
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func prepareSearchQuery(finalQuery *goqu.SelectDataset, p types.InstancesQueryPa
 
 // GetInstances returns all instances that match with the provided criteria.
 func (q *Queries) GetInstances(p types.InstancesQueryParams, duration string) (types.InstancesWithTotal, error) {
-	var instances []*types.Instance
+	instances := []*types.Instance{}
 	var err error
 	totalCount, err := q.GetInstancesCount(p, duration)
 	if err != nil {

--- a/backend/pkg/api/internal/dbreads/packages.go
+++ b/backend/pkg/api/internal/dbreads/packages.go
@@ -81,7 +81,7 @@ func (q *Queries) GetPackages(appID string, page, perPage uint64, searchVersion 
 }
 
 func (q *Queries) getPackagesFromQuery(query string) ([]*types.Package, error) {
-	var pkgs []*types.Package
+	pkgs := []*types.Package{}
 	rows, err := q.db.Queryx(query)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (q *Queries) loadPackageExtras(packages []*types.Package) ([]*types.Package
 		if files, ok := filesByPkg[pkg.ID]; ok {
 			pkg.ExtraFiles = files
 		} else {
-			pkg.ExtraFiles = nil
+			pkg.ExtraFiles = []types.File{}
 		}
 		if action, ok := actionsByPkg[pkg.ID]; ok {
 			pkg.FlatcarAction = action
@@ -218,7 +218,7 @@ func (q *Queries) getExtraFiles(packageID string) ([]types.File, error) {
 		return nil, err
 	}
 
-	var files []types.File
+	files := []types.File{}
 	rows, err := q.db.Queryx(query)
 	if err != nil {
 		return nil, err
@@ -263,7 +263,7 @@ func (q *Queries) getPackage(packageID null.String) (*types.Package, error) {
 	case nil:
 		packageEntity.ExtraFiles = extraFiles
 	case sql.ErrNoRows:
-		packageEntity.ExtraFiles = nil
+		packageEntity.ExtraFiles = []types.File{}
 	default:
 		return nil, err
 	}

--- a/backend/pkg/api/internal/dbreads/packages_floors.go
+++ b/backend/pkg/api/internal/dbreads/packages_floors.go
@@ -217,7 +217,7 @@ func (q *Queries) GetPackageFloorChannels(packageID string) ([]types.ChannelFloo
 	}
 	defer rows.Close()
 
-	var result []types.ChannelFloorInfo
+	result := []types.ChannelFloorInfo{}
 	for rows.Next() {
 		var chWithFloor channelWithFloor
 		if err := rows.StructScan(&chWithFloor); err != nil {

--- a/backend/pkg/api/runtime/activity_test.go
+++ b/backend/pkg/api/runtime/activity_test.go
@@ -68,7 +68,8 @@ func TestGetActivity(t *testing.T) {
 
 	activityEntries, err = a.GetActivity(uuid.New().String(), types.ActivityQueryParams{})
 	assert.NoError(t, err)
-	assert.Nil(t, activityEntries, "Team with this id doesn't exist")
+	assert.Empty(t, activityEntries, "Team with this id doesn't exist")
+	assert.NotNil(t, activityEntries)
 
 	// We try counting with default Start==-3days, End==Now
 	totalCount, err := a.GetActivityCount(tTeam.ID, types.ActivityQueryParams{})

--- a/backend/pkg/handler/groups.go
+++ b/backend/pkg/handler/groups.go
@@ -224,10 +224,6 @@ func (h *Handler) GetGroupVersionBreakdown(ctx echo.Context, _ string, groupID s
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
 
-	if len(versionBreakdown) == 0 {
-		// WAT?: because otherwise it serializes to null not []
-		return ctx.JSON(http.StatusOK, []string{})
-	}
 	return ctx.JSON(http.StatusOK, versionBreakdown)
 }
 

--- a/backend/pkg/handler/packages.go
+++ b/backend/pkg/handler/packages.go
@@ -179,7 +179,7 @@ func packageFromRequest(appID string, arch int, ChannelsBlacklist []string, desc
 		flatcarAction.PackageID = ID
 	}
 
-	var extraFilesArray []types.File
+	extraFilesArray := []types.File{}
 	if extraFiles != nil {
 		for _, file := range *extraFiles {
 			f := types.File{


### PR DESCRIPTION
# fix(api): serialize empty read results as [] instead of null

Fixes #588

`dbreads` declared its result slices with `var x []T`, so a query returning zero rows
yielded a nil slice — which `encoding/json` marshals as `null`. `spec.yaml` declares
these fields `type: array` and marks none of them `nullable`, so the API contradicted
its own contract, and callers compensated with `|| []`.

Initialise the slices as empty at the sites whose values reach a JSON response. Two of
them were explicit `ExtraFiles = nil` assignments, so `"extra_files": null` was emitted
for every package without extra files — the common case.

Also drops the workaround in `GetGroupVersionBreakdown`, which returned `[]string{}`
where the schema expects `versionBreakdownEntry` objects, and only worked because empty
arrays serialize identically regardless of element type.

## Testing done

The new test asserts the marshalled bytes equal `[]` rather than using `assert.Empty`,
which passes for a nil slice too. Confirmed failing on the previous code.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
