### PR TITLE
fix(api): correct regex character class in product ID validation

### DIFF
--- a/backend/pkg/api/admin/applications.go
+++ b/backend/pkg/api/admin/applications.go
@@ -83,6 +83,8 @@ func (s *Service) AddAppCloning(app *types.Application, sourceAppID string) (*ty
 	return app, nil
 }
 
+var productIDRegex = regexp.MustCompile(`^[a-zA-Z]+([a-zA-Z0-9\-]*[a-zA-Z0-9])*(\.[a-zA-Z]+([a-zA-Z0-9\-]*[a-zA-Z0-9])*)+$`)
+
 func validateProductID(productID null.String) error {
 	if productID.Ptr() == nil {
 		return nil
@@ -92,18 +94,7 @@ func validateProductID(productID null.String) error {
 		return fmt.Errorf("product ID %v is not valid (max length 155)", *productID.Ptr())
 	}
 
-	// This regex matches an ID that matches
-	// * At least two segments.
-	// * All characters must be alphanumeric, a dash.
-	// Each segment must start with a letter.
-	// Each segment must not end with a dash.
-	regMatcher := "^[a-zA-Z]+([a-zA-Z0-9\\-]*[a-zA-Z0-9])*(\\.[a-zA-Z]+([a-zA-Z0-1\\-]*[a-zA-Z0-9])*)+$"
-	matches, err := regexp.MatchString(regMatcher, *productID.Ptr())
-	if err != nil {
-		return err
-	}
-
-	if !matches {
+	if !productIDRegex.MatchString(*productID.Ptr()) {
 		return fmt.Errorf("product ID %v is not valid (has to be in the form e.g. io.example.App)", *productID.Ptr())
 	}
 

--- a/backend/pkg/api/applications_test.go
+++ b/backend/pkg/api/applications_test.go
@@ -87,6 +87,12 @@ func TestAddAppCloning(t *testing.T) {
 	_, err = as.AddApp(&Application{Name: "productIDApp3", TeamID: tTeam.ID, ProductID: null.StringFrom("io2.valid12.New-Name")})
 	assert.NoError(t, err)
 
+	_, err = as.AddApp(&Application{Name: "productIDApp3b", TeamID: tTeam.ID, ProductID: null.StringFrom("io.flatcar.v2app")})
+	assert.NoError(t, err)
+
+	_, err = as.AddApp(&Application{Name: "productIDApp3c", TeamID: tTeam.ID, ProductID: null.StringFrom("com.example.app2024.service9")})
+	assert.NoError(t, err)
+
 	_, err = as.AddApp(&Application{Name: "productIDApp4", TeamID: tTeam.ID, ProductID: null.StringFrom("io.invalid.New_Name")})
 	assert.Error(t, err)
 


### PR DESCRIPTION
Fixes a regex character class typo in `validateProductID` where subsegments specified `[a-zA-Z0-1\-]` instead of `[a-zA-Z0-9\-]`. 

While this typo was inadvertently masked by the greedy repetition of the outer group and did not functionally reject product IDs in practice (as the trailing `[a-zA-Z0-9]` in the regex matched digits 2-9), the pattern is now corrected to strictly match the documented alphanumeric intent and prevent future confusion.

Additionally, this PR optimizes performance by pre-compiling `productIDRegex` at the package level using `regexp.MustCompile`, which avoids recompiling the expression on every single API validation call.