### PR TITLE
helm: document NEBRASKA_METRICS_UPDATE_INTERVAL in values.yaml

### DIFF
--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -98,6 +98,9 @@ extraEnvVars:
   # NEBRASKA_DB_MAX_IDLE_CONNS: 25
   # NEBRASKA_DB_CONN_MAX_LIFETIME: 300
   # NEBRASKA_MAX_FLOORS_PER_RESPONSE: 5
+  # Update interval for the Nebraska application metrics.
+  # Go duration string; invalid or non-positive values fall back to 15s.
+  # NEBRASKA_METRICS_UPDATE_INTERVAL: 15s
 
 # extraEnv allows you to set environment variables using values found in your secrets, or any other env spec you might like.
 ## extraEnv:


### PR DESCRIPTION
`NEBRASKA_METRICS_UPDATE_INTERVAL` sets the update interval for the Nebraska application metrics. It defaults to 15s and takes a Go duration string; invalid or non-positive values log a warning and fall back to the default.

It is read via `os.Getenv` in `backend/pkg/metrics/metrics.go`, outside the flag/config system, so it does not appear in `--help` and was not documented anywhere in the repo. This adds it as a commented example next to the other
`os.Getenv`-only vars already listed under `extraEnvVars` (`NEBRASKA_MAX_FLOORS_PER_RESPONSE`, `NEBRASKA_DB_MAX_*`), since it belongs to the same class of setting.

Comments only, so the rendered chart is unchanged.

## How to use

Uncomment the line in `values.yaml`, or set it directly:

    --set extraEnvVars.NEBRASKA_METRICS_UPDATE_INTERVAL=30s

## Testing done

The variable reaches the container env when set:

    $ helm template neb charts/nebraska --set extraEnvVars.NEBRASKA_METRICS_UPDATE_INTERVAL=30s | grep -A1 NEBRASKA_METRICS_UPDATE_INTERVAL
                - name: NEBRASKA_METRICS_UPDATE_INTERVAL
                  value: "30s"

The default render is unaffected, since the added lines are comments:

    $ helm template neb charts/nebraska | grep -c NEBRASKA_METRICS_UPDATE_INTERVAL
    0

Chart still lints:

    $ helm lint charts/nebraska
    1 chart(s) linted, 0 chart(s) failed

- [ ] Changelog entries added in the respective `changelog/` directory - docs-only comment change, no change to rendered output. 

Happy to add an entry under `[Unreleased]` in `CHANGELOG.md` if you would prefer one.