### PR TITLE
metrics: fix application_instances_per_channel disagreeing with UI instance counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bugfixes
 
 - Fixed package blacklist changes not appearing in UI immediately after save
-- **Application instances per channel metric accuracy:** `nebraska_application_instances_per_channel` now excludes instances that have stopped checking in (matching the activity window used elsewhere), counts instances whose group has no channel assigned instead of silently dropping them, and reports amd64/arm64 channels separately via a new `arch` label. The gauge is also reset before each recalculation so series with no more matching instances stop being exported instead of freezing at their last value. ([#1580](https://github.com/flatcar/nebraska/pull/1580))
+- **Application instances per channel metric accuracy:** `nebraska_application_instances_per_channel` now excludes instances that have stopped checking in (matching the activity window used elsewhere), counts instances whose group has no channel assigned instead of silently dropping them, and reports amd64/aarch64 channels separately via a new `arch` label. The gauge is also kept in sync with the underlying data (rather than reset-and-repopulated) so series with no more matching instances stop being exported instead of freezing at their last value. ([#1580](https://github.com/flatcar/nebraska/pull/1580))
 
 ## [3.0.0] - 28/11/2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bugfixes
 
 - Fixed package blacklist changes not appearing in UI immediately after save
+- **Application instances per channel metric accuracy:** `nebraska_application_instances_per_channel` now excludes instances that have stopped checking in (matching the activity window used elsewhere), counts instances whose group has no channel assigned instead of silently dropping them, and reports amd64/arm64 channels separately via a new `arch` label. The gauge is also reset before each recalculation so series with no more matching instances stop being exported instead of freezing at their last value. ([#1580](https://github.com/flatcar/nebraska/pull/1580))
 
 ## [3.0.0] - 28/11/2025
 

--- a/backend/pkg/api/internal/dbreads/metrics.go
+++ b/backend/pkg/api/internal/dbreads/metrics.go
@@ -8,13 +8,25 @@ import (
 )
 
 var (
+	// appInstancesPerChannelMetricSQL only counts instances that are still
+	// considered "active" (i.e. within validityInterval of their last
+	// check-in), matching the activity window used everywhere else
+	// (GetApp, GetApps, GetGroupInstancesStats, GetGroupVersionBreakdown,
+	// GetInstances). It uses LEFT JOINs for groups/channel so instances
+	// whose group has no channel assigned (groups.channel_id can be NULL)
+	// are still counted instead of being silently dropped, and it also
+	// reports the channel's arch so that amd64/arm64 channels sharing the
+	// same name are not folded into a single row.
 	appInstancesPerChannelMetricSQL = fmt.Sprintf(`
-SELECT a.name AS app_name, ia.version AS version, c.name AS channel_name, count(ia.version) AS instances_count
-FROM instance_application ia, application a, channel c, groups g
-WHERE a.id = ia.application_id AND ia.group_id = g.id AND g.channel_id = c.id AND %s
-GROUP BY app_name, version, channel_name
-ORDER BY app_name, version, channel_name
-`, ignoreFakeInstanceCondition("ia.instance_id"))
+SELECT a.name AS app_name, ia.version AS version, COALESCE(c.name, '') AS channel_name, COALESCE(c.arch, -1) AS arch, count(ia.version) AS instances_count
+FROM instance_application ia
+JOIN application a ON a.id = ia.application_id
+LEFT JOIN groups g ON ia.group_id = g.id
+LEFT JOIN channel c ON g.channel_id = c.id
+WHERE ia.last_check_for_updates > now() at time zone 'utc' - interval '%[1]s' AND %[2]s
+GROUP BY app_name, version, channel_name, arch
+ORDER BY app_name, version, channel_name, arch
+`, validityInterval, ignoreFakeInstanceCondition("ia.instance_id"))
 
 	failedUpdatesSQL = fmt.Sprintf(`
 SELECT a.name AS app_name, count(*) as fail_count

--- a/backend/pkg/api/internal/dbreads/metrics.go
+++ b/backend/pkg/api/internal/dbreads/metrics.go
@@ -15,7 +15,7 @@ var (
 	// GetInstances). It uses LEFT JOINs for groups/channel so instances
 	// whose group has no channel assigned (groups.channel_id can be NULL)
 	// are still counted instead of being silently dropped, and it also
-	// reports the channel's arch so that amd64/arm64 channels sharing the
+	// reports the channel's arch so that amd64/aarch64 channels sharing the
 	// same name are not folded into a single row.
 	appInstancesPerChannelMetricSQL = fmt.Sprintf(`
 SELECT a.name AS app_name, ia.version AS version, COALESCE(c.name, '') AS channel_name, COALESCE(c.arch, -1) AS arch, count(ia.version) AS instances_count

--- a/backend/pkg/api/metrics_test.go
+++ b/backend/pkg/api/metrics_test.go
@@ -2,11 +2,16 @@ package api
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/types"
 )
+
+// sampleAppArch is the arch of every channel created by sample_data.sql for
+// "Sample application" (see migration 0007_add_package_arch.sql).
+const sampleAppArch = int(types.ArchAMD64)
 
 func TestGetAppInstancesPerChannelMetrics(t *testing.T) {
 	a := newForTest(t)
@@ -20,53 +25,173 @@ func TestGetAppInstancesPerChannelMetrics(t *testing.T) {
 			ApplicationName: "Sample application",
 			Version:         "1.0.1",
 			ChannelName:     "Failing",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.1",
 			ChannelName:     "Master",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.1",
 			ChannelName:     "Stable",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.2",
 			ChannelName:     "Master",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.2",
 			ChannelName:     "Stable",
+			Arch:            sampleAppArch,
 			InstancesCount:  2,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.3",
 			ChannelName:     "Master",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.3",
 			ChannelName:     "Stable",
+			Arch:            sampleAppArch,
 			InstancesCount:  4,
 		},
 		{
 			ApplicationName: "Sample application",
 			Version:         "1.0.4",
 			ChannelName:     "Master",
+			Arch:            sampleAppArch,
 			InstancesCount:  1,
 		},
 	}
 
 	require.Equal(t, expectedMetrics, metrics)
+}
+
+// TestGetAppInstancesPerChannelMetricsExcludesStaleInstances checks that an
+// instance is dropped from the metric once it stops checking in, matching
+// the activity window (validityInterval) used by GetApp/GetApps/GetInstances
+// and friends. Regression test for
+// https://github.com/flatcar/nebraska/issues/1562.
+func TestGetAppInstancesPerChannelMetricsExcludesStaleInstances(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	// Make every sample instance look like it hasn't checked in for 400 days.
+	longAgo := time.Now().UTC().AddDate(0, 0, -400)
+	_, err := a.db().Exec(`UPDATE instance_application SET last_check_for_updates = $1`, longAgo)
+	require.NoError(t, err)
+
+	metrics, err := a.GetAppInstancesPerChannelMetrics()
+	require.NoError(t, err)
+	require.Empty(t, metrics, "instances that stopped checking in long ago must not be counted")
+}
+
+// TestGetAppInstancesPerChannelMetricsIncludesGroupsWithoutChannel checks
+// that instances belonging to a group with no channel assigned
+// (groups.channel_id can be NULL, e.g. after the channel was deleted) are
+// still counted instead of being silently dropped by the join. Regression
+// test for https://github.com/flatcar/nebraska/issues/1562.
+func TestGetAppInstancesPerChannelMetricsIncludesGroupsWithoutChannel(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	// "Prod EC2 us-west-2" (bcaa68bc-...) has 3 active instances pointed at
+	// the "Stable" channel: instance1 (1.0.3), instance2 (1.0.3), instance3 (1.0.2).
+	_, err := a.db().Exec(`UPDATE groups SET channel_id = NULL WHERE id = 'bcaa68bc-5f82-11e5-9d70-feff819cdc9f'`)
+	require.NoError(t, err)
+
+	metrics, err := a.GetAppInstancesPerChannelMetrics()
+	require.NoError(t, err)
+
+	var totalInstances int
+	var noChannel103, noChannel102 int
+	for _, m := range metrics {
+		totalInstances += m.InstancesCount
+		if m.ChannelName == "" {
+			require.Equal(t, -1, m.Arch, "instances without a channel must not report a real arch")
+			switch m.Version {
+			case "1.0.3":
+				noChannel103 = m.InstancesCount
+			case "1.0.2":
+				noChannel102 = m.InstancesCount
+			}
+		}
+	}
+
+	require.Equal(t, 12, totalInstances, "all 12 active sample instances must still be counted, channel or not")
+	require.Equal(t, 2, noChannel103, "instance1 and instance2 should fall into the no-channel bucket")
+	require.Equal(t, 1, noChannel102, "instance3 should fall into the no-channel bucket")
+}
+
+// TestGetAppInstancesPerChannelMetricsSeparatesArch checks that two channels
+// that share a name but differ by arch (e.g. "stable" for amd64 and arm64,
+// see migration 0008-arm-channels-groups.sql) are reported as separate
+// rows instead of being folded together by GROUP BY channel_name. Regression
+// test for https://github.com/flatcar/nebraska/issues/1562.
+func TestGetAppInstancesPerChannelMetricsSeparatesArch(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	const (
+		appID         = "b6458005-8f40-4627-b33b-be70a718c48e" // "Sample application"
+		packageID     = "12697fa4-5f83-11e5-9d70-feff819cdc9f" // existing "Stable" package for appID
+		archChannelID = "cb2deea8-5f83-11e5-9d70-feff819cdc9e"
+		archGroupID   = "bcaa68bc-5f82-11e5-9d70-feff819cda00"
+	)
+
+	// A second "Stable" channel for the same application, but for arm64.
+	_, err := a.db().Exec(`
+		INSERT INTO channel (id, name, color, application_id, package_id, arch)
+		VALUES ($1, 'Stable', '#0099FF', $2, $3, $4)`,
+		archChannelID, appID, packageID, int(types.ArchAArch64))
+	require.NoError(t, err)
+
+	_, err = a.db().Exec(`
+		INSERT INTO groups (id, name, description, policy_period_interval, policy_max_updates_per_period, policy_update_timeout, application_id, channel_id, track)
+		VALUES ($1, 'Prod EC2 us-west-2 (arm64)', 'Production servers, west coast, arm64', '15 minutes', 2, '60 minutes', $2, $3, $4)`,
+		archGroupID, appID, archChannelID, archGroupID)
+	require.NoError(t, err)
+
+	_, err = a.db().Exec(`INSERT INTO instance (id, ip) VALUES ('instance-arm1', '10.0.0.100')`)
+	require.NoError(t, err)
+
+	_, err = a.db().Exec(`
+		INSERT INTO instance_application (version, instance_id, application_id, group_id)
+		VALUES ('1.0.3', 'instance-arm1', $1, $2)`, appID, archGroupID)
+	require.NoError(t, err)
+
+	metrics, err := a.GetAppInstancesPerChannelMetrics()
+	require.NoError(t, err)
+
+	var amd64Stable103, arm64Stable103 int
+	for _, m := range metrics {
+		if m.ApplicationName == "Sample application" && m.ChannelName == "Stable" && m.Version == "1.0.3" {
+			switch m.Arch {
+			case int(types.ArchAMD64):
+				amd64Stable103 = m.InstancesCount
+			case int(types.ArchAArch64):
+				arm64Stable103 = m.InstancesCount
+			}
+		}
+	}
+
+	require.Equal(t, 4, amd64Stable103, "existing amd64 Stable/1.0.3 count must be unaffected")
+	require.Equal(t, 1, arm64Stable103, "the new arm64 instance must show up as its own series")
 }
 
 func TestGetFailedUpdatesMetrics(t *testing.T) {

--- a/backend/pkg/api/types/metrics.go
+++ b/backend/pkg/api/types/metrics.go
@@ -4,7 +4,11 @@ type AppInstancesPerChannelMetric struct {
 	ApplicationName string `db:"app_name" json:"app_name"`
 	Version         string `db:"version" json:"version"`
 	ChannelName     string `db:"channel_name" json:"channel_name"`
-	InstancesCount  int    `db:"instances_count" json:"instances_count"`
+	// Arch is the numeric value of the channel's Arch (see arch.go). It is
+	// -1 when the instance's group has no channel (or no group) assigned,
+	// in which case ChannelName is also "".
+	Arch           int `db:"arch" json:"arch"`
+	InstancesCount int `db:"instances_count" json:"instances_count"`
 }
 
 type FailedUpdatesMetric struct {

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -24,7 +24,7 @@ const noChannelArchLabel = "none"
 // empty, per the check constraint requiring a non-empty name), which we map
 // here to an explicit sentinel instead of exporting channel="" - an empty
 // label value is easy to miss/hard to filter for in PromQL.
-const noChannelLabel = "none"
+const noChannelLabel = "__no_channel__"
 
 const (
 	defaultMetricsUpdateInterval = 15 * time.Second
@@ -98,11 +98,11 @@ var (
 )
 
 // labelKey joins label values into a single map key so removed label
-// combinations can be detected between calculateMetrics runs. It doesn't
-// need to be collision-proof against label values containing the
-// separator: a spurious collision would only cause an extra
-// DeleteLabelValues + re-Set on the next run, never an incorrectly
-// exported value.
+// combinations can be detected between calculateMetrics runs.
+//
+// "\x00" is used as a separator because these label values originate from
+// Postgres text/varchar fields (which cannot contain NUL bytes), making the
+// join unambiguous.
 func labelKey(labels []string) string {
 	return strings.Join(labels, "\x00")
 }

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -147,6 +147,16 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get app instances per channel metrics: %w", err)
 	}
 
+	// Reset before repopulating: the DB query only returns label
+	// combinations that currently have active instances, but the
+	// Prometheus client library keeps every previously-seen label
+	// combination (and its last value) registered until it's explicitly
+	// removed. Without this, a series whose instances all went stale, or
+	// whose channel was deleted, would keep exporting its last non-zero
+	// count forever, undermining the freshness filter in
+	// GetAppInstancesPerChannelMetrics and making the metric disagree
+	// with the UI again.
+	appInstancePerChannelGaugeMetric.Reset()
 	for _, metric := range aipcMetrics {
 		archLabel := noChannelArchLabel
 		if metric.Arch >= 0 {
@@ -160,6 +170,9 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get failed update metrics: %w", err)
 	}
 
+	// Same reasoning as above: an application with no failed updates left
+	// should stop being exported instead of keeping its last count.
+	failedUpdatesGaugeMetric.Reset()
 	for _, metric := range fuMetrics {
 		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
 	}

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,6 +17,14 @@ import (
 // group has no channel (or no group) assigned, since there is no
 // architecture to report in that case.
 const noChannelArchLabel = "none"
+
+// noChannelLabel is the "channel" label value used for instances whose
+// group has no channel (or no group) assigned. GetAppInstancesPerChannelMetrics
+// reports this case as an empty ChannelName (channel.name can never itself be
+// empty, per the check constraint requiring a non-empty name), which we map
+// here to an explicit sentinel instead of exporting channel="" - an empty
+// label value is easy to miss/hard to filter for in PromQL.
+const noChannelLabel = "none"
 
 const (
 	defaultMetricsUpdateInterval = 15 * time.Second
@@ -33,7 +42,7 @@ var (
 			"version",
 			"channel",
 			// arch distinguishes channels that share the same name across
-			// architectures (e.g. "stable" for amd64 and arm64). This is a
+			// architectures (e.g. "stable" for amd64 and aarch64). This is a
 			// new label: existing dashboards/alerts that group solely by
 			// application/version/channel should add `by (arch)` or sum()
 			// over the new label to keep prior totals.
@@ -77,7 +86,43 @@ var (
 	)
 
 	l = logger.New("nebraska")
+
+	// lastAipcLabelSets and lastFuLabelSets track the label combinations
+	// exported on the previous calculateMetrics run, keyed by labelKey.
+	// They're only ever read/written from the single ticker goroutine
+	// started in RegisterAndInstrument (calculateMetrics is never called
+	// concurrently with itself outside of tests, which also call it
+	// sequentially), so no extra locking is needed.
+	lastAipcLabelSets = map[string][]string{}
+	lastFuLabelSets   = map[string][]string{}
 )
+
+// labelKey joins label values into a single map key so removed label
+// combinations can be detected between calculateMetrics runs. It doesn't
+// need to be collision-proof against label values containing the
+// separator: a spurious collision would only cause an extra
+// DeleteLabelValues + re-Set on the next run, never an incorrectly
+// exported value.
+func labelKey(labels []string) string {
+	return strings.Join(labels, "\x00")
+}
+
+// syncGaugeVec upserts every entry in newLabelSets (using values for each
+// series' new value) into vec, then removes any label combination present
+// in prevLabelSets but absent from newLabelSets. Unlike Reset() followed by
+// repopulating, this never makes the whole metric family briefly empty or
+// partial, so a concurrent Prometheus scrape always observes either the
+// previous or the new value for every series, never a gap.
+func syncGaugeVec(vec *prometheus.GaugeVec, prevLabelSets, newLabelSets map[string][]string, values map[string]float64) {
+	for key, labels := range newLabelSets {
+		vec.WithLabelValues(labels...).Set(values[key])
+	}
+	for key, labels := range prevLabelSets {
+		if _, stillPresent := newLabelSets[key]; !stillPresent {
+			vec.DeleteLabelValues(labels...)
+		}
+	}
+}
 
 // registerNebraskaMetrics registers the application metrics collector with the DefaultRegistrer.
 func registerNebraskaMetrics() error {
@@ -147,23 +192,29 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get app instances per channel metrics: %w", err)
 	}
 
-	// Reset before repopulating: the DB query only returns label
-	// combinations that currently have active instances, but the
-	// Prometheus client library keeps every previously-seen label
-	// combination (and its last value) registered until it's explicitly
-	// removed. Without this, a series whose instances all went stale, or
-	// whose channel was deleted, would keep exporting its last non-zero
-	// count forever, undermining the freshness filter in
-	// GetAppInstancesPerChannelMetrics and making the metric disagree
-	// with the UI again.
-	appInstancePerChannelGaugeMetric.Reset()
+	// Sync (rather than Reset()+repopulate) so a series whose instances
+	// all went stale, or whose channel was deleted, stops being exported
+	// instead of keeping its last non-zero count forever — without ever
+	// making the whole metric family briefly empty for a concurrent
+	// scrape (see syncGaugeVec).
+	newAipcLabelSets := make(map[string][]string, len(aipcMetrics))
+	aipcValues := make(map[string]float64, len(aipcMetrics))
 	for _, metric := range aipcMetrics {
 		archLabel := noChannelArchLabel
 		if metric.Arch >= 0 {
 			archLabel = types.Arch(uint(metric.Arch)).String()
 		}
-		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName, archLabel).Set(float64(metric.InstancesCount))
+		channelLabel := metric.ChannelName
+		if channelLabel == "" {
+			channelLabel = noChannelLabel
+		}
+		labels := []string{metric.ApplicationName, metric.Version, channelLabel, archLabel}
+		key := labelKey(labels)
+		newAipcLabelSets[key] = labels
+		aipcValues[key] = float64(metric.InstancesCount)
 	}
+	syncGaugeVec(appInstancePerChannelGaugeMetric, lastAipcLabelSets, newAipcLabelSets, aipcValues)
+	lastAipcLabelSets = newAipcLabelSets
 
 	fuMetrics, err := api.GetFailedUpdatesMetrics()
 	if err != nil {
@@ -172,10 +223,16 @@ func calculateMetrics(api *api.API) error {
 
 	// Same reasoning as above: an application with no failed updates left
 	// should stop being exported instead of keeping its last count.
-	failedUpdatesGaugeMetric.Reset()
+	newFuLabelSets := make(map[string][]string, len(fuMetrics))
+	fuValues := make(map[string]float64, len(fuMetrics))
 	for _, metric := range fuMetrics {
-		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
+		labels := []string{metric.ApplicationName}
+		key := labelKey(labels)
+		newFuLabelSets[key] = labels
+		fuValues[key] = float64(metric.FailureCount)
 	}
+	syncGaugeVec(failedUpdatesGaugeMetric, lastFuLabelSets, newFuLabelSets, fuValues)
+	lastFuLabelSets = newFuLabelSets
 
 	// db stats
 	dbStats := api.DbStats()

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -8,8 +8,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/flatcar/nebraska/backend/pkg/api"
+	"github.com/flatcar/nebraska/backend/pkg/api/types"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
 )
+
+// noChannelArchLabel is the "arch" label value used for instances whose
+// group has no channel (or no group) assigned, since there is no
+// architecture to report in that case.
+const noChannelArchLabel = "none"
 
 const (
 	defaultMetricsUpdateInterval = 15 * time.Second
@@ -26,6 +32,12 @@ var (
 			"application",
 			"version",
 			"channel",
+			// arch distinguishes channels that share the same name across
+			// architectures (e.g. "stable" for amd64 and arm64). This is a
+			// new label: existing dashboards/alerts that group solely by
+			// application/version/channel should add `by (arch)` or sum()
+			// over the new label to keep prior totals.
+			"arch",
 		},
 	)
 
@@ -136,7 +148,11 @@ func calculateMetrics(api *api.API) error {
 	}
 
 	for _, metric := range aipcMetrics {
-		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName).Set(float64(metric.InstancesCount))
+		archLabel := noChannelArchLabel
+		if metric.Arch >= 0 {
+			archLabel = types.Arch(uint(metric.Arch)).String()
+		}
+		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName, archLabel).Set(float64(metric.InstancesCount))
 	}
 
 	fuMetrics, err := api.GetFailedUpdatesMetrics()

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -1,0 +1,75 @@
+package metrics
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" sql driver used below
+
+	"github.com/flatcar/nebraska/backend/pkg/api"
+)
+
+const defaultTestDbURL string = "postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10"
+
+func newAPIForTest(t *testing.T) *api.API {
+	t.Helper()
+
+	if _, ok := os.LookupEnv("NEBRASKA_DB_URL"); !ok {
+		require.NoError(t, os.Setenv("NEBRASKA_DB_URL", defaultTestDbURL))
+	}
+
+	a, err := api.NewForTest(api.OptionInitDB)
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	return a
+}
+
+// TestCalculateMetricsResetsStaleSeries checks that calculateMetrics removes
+// Prometheus series whose underlying data has disappeared (e.g. every
+// instance for a version/channel/arch went stale, or an application has no
+// more failed updates) instead of leaving their last exported value in
+// place forever, which would undermine the activity-window filtering added
+// to GetAppInstancesPerChannelMetrics and make the metric disagree with the
+// UI again. Regression test for the review discussion on
+// https://github.com/flatcar/nebraska/pull/1580.
+func TestCalculateMetricsResetsStaleSeries(t *testing.T) {
+	a := newAPIForTest(t)
+	defer a.Close()
+
+	// Independent connection to the same test database, since api.API's
+	// own connection is not exported outside pkg/api.
+	db, err := sqlx.Connect("pgx", os.Getenv("NEBRASKA_DB_URL"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, calculateMetrics(a))
+	require.Positive(t, testutil.CollectAndCount(appInstancePerChannelGaugeMetric),
+		"sample_data.sql has active instances, so the gauge should have at least one series after the first calculation")
+	require.Positive(t, testutil.CollectAndCount(failedUpdatesGaugeMetric),
+		"sample_data.sql has instances with failed updates, so the gauge should have at least one series after the first calculation")
+
+	// Make every sample instance look like it hasn't checked in for 400
+	// days, and remove the one "failed update" event in the sample data,
+	// so both underlying queries now return nothing.
+	longAgo := time.Now().UTC().AddDate(0, 0, -400)
+	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1`, longAgo)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		DELETE FROM event
+		USING event_type
+		WHERE event.event_type_id = event_type.id AND event_type.type = 3 AND event_type.result = 0`)
+	require.NoError(t, err)
+
+	require.NoError(t, calculateMetrics(a))
+
+	require.Equal(t, 0, testutil.CollectAndCount(appInstancePerChannelGaugeMetric),
+		"series with no more matching instances must be removed by Reset(), not left exporting their last value")
+	require.Equal(t, 0, testutil.CollectAndCount(failedUpdatesGaugeMetric),
+		"series with no more matching instances must be removed by Reset(), not left exporting their last value")
+}

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -19,6 +19,18 @@ import (
 
 const defaultTestDbURL string = "postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10"
 
+// TestMain lets NEBRASKA_SKIP_TESTS bypass this package's tests, consistent
+// with other DB-backed test packages (see pkg/api, pkg/random, etc.), since
+// make code-checks runs `NEBRASKA_SKIP_TESTS=1 go test ./...` in
+// environments without a Postgres test database available.
+func TestMain(m *testing.M) {
+	if os.Getenv("NEBRASKA_SKIP_TESTS") != "" {
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
 func newAPIForTest(t *testing.T) *api.API {
 	t.Helper()
 

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -118,12 +118,12 @@ func TestCalculateMetricsRemovesStaleSeries(t *testing.T) {
 		"series with no more matching instances must be synced away, not left exporting their last value")
 }
 
-// TestCalculateMetricsUsesNoneSentinelForNoChannel checks that instances
-// whose group has no channel assigned are exported with an explicit
-// channel="none" label, never channel="" — an empty label value is easy to
+// TestCalculateMetricsUsesReservedSentinelForNoChannel checks that instances
+// whose group has no channel assigned are exported with the reserved
+// noChannelLabel value, never channel="" — an empty label value is easy to
 // miss or hard to filter for in PromQL. Regression test for the review
 // discussion on https://github.com/flatcar/nebraska/pull/1580.
-func TestCalculateMetricsUsesNoneSentinelForNoChannel(t *testing.T) {
+func TestCalculateMetricsUsesReservedSentinelForNoChannel(t *testing.T) {
 	resetMetricsState(t)
 
 	a := newAPIForTest(t)

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
@@ -30,7 +33,46 @@ func newAPIForTest(t *testing.T) *api.API {
 	return a
 }
 
-// TestCalculateMetricsResetsStaleSeries checks that calculateMetrics removes
+// resetMetricsState clears both GaugeVecs and their label-tracking maps, so
+// each test starts from a clean slate despite these being package-level
+// singletons shared across the whole test binary.
+func resetMetricsState(t *testing.T) {
+	t.Helper()
+
+	appInstancePerChannelGaugeMetric.Reset()
+	failedUpdatesGaugeMetric.Reset()
+	lastAipcLabelSets = map[string][]string{}
+	lastFuLabelSets = map[string][]string{}
+}
+
+// collectLabelValues returns every value seen for labelName across all
+// series currently exported by vec.
+func collectLabelValues(t *testing.T, vec *prometheus.GaugeVec, labelName string) []string {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 64)
+	go func() {
+		vec.Collect(ch)
+		close(ch)
+	}()
+
+	var values []string
+
+	for m := range ch {
+		var dtoM dto.Metric
+		require.NoError(t, m.Write(&dtoM))
+
+		for _, lp := range dtoM.GetLabel() {
+			if lp.GetName() == labelName {
+				values = append(values, lp.GetValue())
+			}
+		}
+	}
+
+	return values
+}
+
+// TestCalculateMetricsRemovesStaleSeries checks that calculateMetrics removes
 // Prometheus series whose underlying data has disappeared (e.g. every
 // instance for a version/channel/arch went stale, or an application has no
 // more failed updates) instead of leaving their last exported value in
@@ -38,7 +80,9 @@ func newAPIForTest(t *testing.T) *api.API {
 // to GetAppInstancesPerChannelMetrics and make the metric disagree with the
 // UI again. Regression test for the review discussion on
 // https://github.com/flatcar/nebraska/pull/1580.
-func TestCalculateMetricsResetsStaleSeries(t *testing.T) {
+func TestCalculateMetricsRemovesStaleSeries(t *testing.T) {
+	resetMetricsState(t)
+
 	a := newAPIForTest(t)
 	defer a.Close()
 
@@ -69,7 +113,34 @@ func TestCalculateMetricsResetsStaleSeries(t *testing.T) {
 	require.NoError(t, calculateMetrics(a))
 
 	require.Equal(t, 0, testutil.CollectAndCount(appInstancePerChannelGaugeMetric),
-		"series with no more matching instances must be removed by Reset(), not left exporting their last value")
+		"series with no more matching instances must be synced away, not left exporting their last value")
 	require.Equal(t, 0, testutil.CollectAndCount(failedUpdatesGaugeMetric),
-		"series with no more matching instances must be removed by Reset(), not left exporting their last value")
+		"series with no more matching instances must be synced away, not left exporting their last value")
+}
+
+// TestCalculateMetricsUsesNoneSentinelForNoChannel checks that instances
+// whose group has no channel assigned are exported with an explicit
+// channel="none" label, never channel="" — an empty label value is easy to
+// miss or hard to filter for in PromQL. Regression test for the review
+// discussion on https://github.com/flatcar/nebraska/pull/1580.
+func TestCalculateMetricsUsesNoneSentinelForNoChannel(t *testing.T) {
+	resetMetricsState(t)
+
+	a := newAPIForTest(t)
+	defer a.Close()
+
+	db, err := sqlx.Connect("pgx", os.Getenv("NEBRASKA_DB_URL"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// "Prod EC2 us-west-2" (bcaa68bc-...) has active instances; drop its
+	// channel assignment so they fall into the no-channel bucket.
+	_, err = db.Exec(`UPDATE groups SET channel_id = NULL WHERE id = 'bcaa68bc-5f82-11e5-9d70-feff819cdc9f'`)
+	require.NoError(t, err)
+
+	require.NoError(t, calculateMetrics(a))
+
+	channelValues := collectLabelValues(t, appInstancePerChannelGaugeMetric, "channel")
+	require.Contains(t, channelValues, noChannelLabel)
+	require.NotContains(t, channelValues, "")
 }


### PR DESCRIPTION
# application_instances_per_channel metric undercounts/miscounts instances

The `nebraska_application_instances_per_channel` gauge had three bugs relative
to the rest of the codebase:

1. **Dead instances counted forever** — the query never filtered on
   `last_check_for_updates`, so instances that stopped checking in stayed in
   the metric indefinitely instead of aging out like every other
   activity-based query (`GetApp`, `GetApps`, `GetInstances`, etc).
2. **Instances with no channel silently dropped** — the query used comma
   joins across `groups`/`channel`, so any instance whose group had no
   channel assigned (`groups.channel_id` can be NULL) disappeared from the
   metric entirely rather than being counted.
3. **amd64/arm64 channels merged into one series** — the query grouped only
   by channel name, so two channels sharing a name across architectures
   (e.g. "stable" for amd64 and arm64) were folded into a single row.

This fixes all three: adds the same freshness filter used elsewhere, switches
to `LEFT JOIN` for groups/channel so channel-less instances land in an
explicit "no channel" bucket instead of vanishing, and adds `arch` to the
grouping so per-architecture counts are reported separately.

Fixes #1562

## How to use

No config or API changes — the fix is internal to how
`GetAppInstancesPerChannelMetrics` computes the `application_instances_per_channel`
Prometheus gauge. Reviewers can validate by scraping `/metrics` on a
Nebraska instance with some inactive instances and/or a channel-less group
and confirming the counts now match what's shown in the instances UI.

**Note:** this PR adds a new `arch` label to the `application_instances_per_channel`
gauge. This is a breaking change for any existing dashboards/alerts that group
by `application`/`version`/`channel` alone — they'll now see one series per
(channel, arch) pair instead of one per channel. Flagging this explicitly in
case maintainers would rather split the label change into a separate PR from
the activity-window/no-channel fixes.

## Testing done

Added/updated unit tests in `backend/pkg/api/metrics_test.go` covering all
three bugs, run against `sample_data.sql` via the local Postgres test service:

### Test Results

````md
cd backend
docker compose -f ./docker-compose.test.yaml up -d postgres
NEBRASKA_DB_URL="postgres://postgres:nebraska@127.0.0.1:8001/nebraska_tests?sslmode=disable&connect_timeout=10"
go test ./pkg/api/... -run 'TestGetAppInstancesPerChannelMetrics' -v
docker compose -f ./docker-compose.test.yaml down
````

### Output

```text
=== RUN TestGetAppInstancesPerChannelMetrics
--- PASS: TestGetAppInstancesPerChannelMetrics (0.06s)
=== RUN TestGetAppInstancesPerChannelMetricsExcludesStaleInstances
--- PASS: TestGetAppInstancesPerChannelMetricsExcludesStaleInstances (0.07s)
=== RUN TestGetAppInstancesPerChannelMetricsIncludesGroupsWithoutChannel
--- PASS: TestGetAppInstancesPerChannelMetricsIncludesGroupsWithoutChannel (0.07s)
=== RUN TestGetAppInstancesPerChannelMetricsSeparatesArch
--- PASS: TestGetAppInstancesPerChannelMetricsSeparatesArch (0.07s)
PASS
ok github.com/flatcar/nebraska/backend/pkg/api 0.342s
```

All targeted tests pass successfully.

> **Note:** I wasn't able to run the full `code-checks` (`golangci-lint`) target locally due to environment constraints. Happy to address any lint feedback from CI.

```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
