### PR TITLE
fix(helm): default PostgreSQL to the official maintained image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+
+- **helm/postgresql: default to the official `docker.io/postgres` image:** the chart pulled PostgreSQL from `bitnamilegacy/postgresql`, the frozen archive Bitnami moved its free catalog into. Those images are never rebuilt, so every PostgreSQL and OS-package CVE published from now on stays unpatched in them. The default is now `docker.io/postgres:17.10-trixie`, which is rebuilt for security updates. The data directory moves from `/bitnami/postgresql/data` to `/var/lib/postgresql/pgdata`; deployments with `postgresql.primary.persistence.enabled=true` need a dump and restore, see [Migrating from the Bitnami PostgreSQL image](charts/nebraska/README.md#migrating-from-the-bitnami-postgresql-image). This replaces the temporary Bitnami Legacy workaround from ([#1227](https://github.com/flatcar/nebraska/pull/1227)).
+
 ### Added
 
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -123,6 +123,13 @@ procedure above, with two additions:
   the official image, and `postgresql.auth.postgresPassword` is then unused. Set
   the password of the user Nebraska connects with through `postgresql.auth.password`.
 
+If your values file already overrides `postgresql.image.registry`,
+`postgresql.image.repository`, `postgresql.image.tag`,
+`postgresql.postgresqlDataDir`, or `postgresql.primary.persistence.mountPath`
+from a previous install, update those overrides to the values above. An old
+override will keep pointing at the bitnami image and paths, and the steps in
+this section will not apply.
+
 ## Parameters
 
 ### Global parameters

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -88,8 +88,8 @@ statefulset.apps/nebraska-postgresql scaled
 
 3. Upgrade PostgreSQL version, e.g:
 ```diff
--          image: docker.io/bitnami/postgresql:13.8.0-debian-11-r18
-+          image: docker.io/bitnamilegacy/postgresql:17.5.0
+-          image: docker.io/postgres:17.10-trixie
++          image: docker.io/postgres:18.2-trixie
 ```
 
 5. Apply the changes and scale up Nebraska statefulset to its original value
@@ -100,6 +100,28 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 ```
 
 7. Scale up Nebraska deployment and assert that everything is back to normal
+
+### Migrating from the Bitnami PostgreSQL image
+
+Charts up to 2.0.0 defaulted to `bitnamilegacy/postgresql`, an archive that is no
+longer rebuilt and therefore never receives security fixes. The default is now the
+official `docker.io/postgres` image.
+
+If persistence is disabled (the default) there is nothing to do: the database is
+recreated on upgrade as before.
+
+If persistence is enabled, the existing volume cannot be reused in place, because
+the Bitnami image keeps `postgresql.conf` and `pg_hba.conf` outside the data
+directory and runs `initdb` against a different glibc, which the official image
+reports as a collation version mismatch. Migrate with a dump and restore using the
+procedure above, with two additions:
+
+- The data directory moves from `/bitnami/postgresql/data` to
+  `/var/lib/postgresql/pgdata`. The old directory is left untouched on the volume;
+  remove it once the restore is verified.
+- `postgresql.auth.username` values other than `postgres` become the superuser of
+  the official image, and `postgresql.auth.postgresPassword` is then unused. Set
+  the password of the user Nebraska connects with through `postgresql.auth.password`.
 
 ## Parameters
 
@@ -213,8 +235,12 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 | `postgresql.enabled`                                     | Enable Bitnami postgresql subchart and deploy database within this helm release                               | `true`                 |
 | `postgresql.auth.database`                               | PostgreSQL database                                                                                           | `nebraska`             |
 | `postgresql.auth.postgresPassword`                       | PostgreSQL password of user "postgres" **Recommended to change it to something secure for security reasons.** | `changeIt`             |
-| `postgresql.image.tag`                                   | PostgreSQL Image tag                                                                                          | `13.8.0-debian-11-r18` |
+| `postgresql.image.registry`                              | PostgreSQL Image registry                                                                                     | `docker.io`            |
+| `postgresql.image.repository`                            | PostgreSQL Image repository                                                                                   | `postgres`             |
+| `postgresql.image.tag`                                   | PostgreSQL Image tag                                                                                          | `17.10-trixie`         |
+| `postgresql.postgresqlDataDir`                           | PostgreSQL data directory (`PGDATA`)                                                                          | `/var/lib/postgresql/pgdata` |
 | `postgresql.primary.persistence.enabled`                 | Enable persistence using PVC                                                                                  | `false`                |
+| `postgresql.primary.persistence.mountPath`               | Mount path of the PostgreSQL volume                                                                           | `/var/lib/postgresql`  |
 | `postgresql.primary.persistence.storageClass`            | PVC Storage Class for PostgreSQL volume                                                                       | `nil`                  |
 | `postgresql.primary.persistence.accessModes`             | PVC Access Mode for PostgreSQL volume                                                                         | `["ReadWriteOnce"]`    |
 | `postgresql.primary.persistence.size`                    | PVC Storage Request for PostgreSQL volume                                                                     | `1Gi`                  |

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -207,13 +207,26 @@ postgresql:
     username: postgres
     database: nebraska
     postgresPassword: changeIt
+  # The official PostgreSQL image is used instead of a Bitnami one: the
+  # `bitnamilegacy/*` repositories are a frozen archive that is never rebuilt,
+  # so images pulled from them accumulate unpatched CVEs. The subchart drives
+  # the official image through POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB and
+  # PGDATA, which docker.io/postgres honours as well.
+  # Note: `auth.username` values other than "postgres" become the superuser of
+  # the official image, and `auth.postgresPassword` is then unused.
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: 17.5.0
+    repository: postgres
+    tag: 17.10-trixie
+  # The official image has no /bitnami tree, so the data directory moves under
+  # /var/lib/postgresql. It must be a subdirectory the container user creates
+  # itself: /var/lib/postgresql and /var/lib/postgresql/data ship as 1777 in
+  # the image and PostgreSQL rejects a data directory with those permissions.
+  postgresqlDataDir: /var/lib/postgresql/pgdata
   primary:
     persistence:
       enabled: false
+      mountPath: /var/lib/postgresql
       storageClass:
       accessModes:
         - ReadWriteOnce

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -207,21 +207,12 @@ postgresql:
     username: postgres
     database: nebraska
     postgresPassword: changeIt
-  # The official PostgreSQL image is used instead of a Bitnami one: the
-  # `bitnamilegacy/*` repositories are a frozen archive that is never rebuilt,
-  # so images pulled from them accumulate unpatched CVEs. The subchart drives
-  # the official image through POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB and
-  # PGDATA, which docker.io/postgres honours as well.
-  # Note: `auth.username` values other than "postgres" become the superuser of
-  # the official image, and `auth.postgresPassword` is then unused.
+  # Official PostgreSQL image, see README for migration notes from bitnamilegacy.
   image:
     registry: docker.io
     repository: postgres
     tag: 17.10-trixie
-  # The official image has no /bitnami tree, so the data directory moves under
-  # /var/lib/postgresql. It must be a subdirectory the container user creates
-  # itself: /var/lib/postgresql and /var/lib/postgresql/data ship as 1777 in
-  # the image and PostgreSQL rejects a data directory with those permissions.
+  # Data directory under the official image, see README for migration notes.
   postgresqlDataDir: /var/lib/postgresql/pgdata
   primary:
     persistence:


### PR DESCRIPTION
Fixes #1574

## Summary

The chart pulled PostgreSQL from bitnamilegacy/postgresql, the frozen
archive Bitnami moved its free catalog into when it retired free image
maintenance. Never rebuilt, so every PostgreSQL and OS-package CVE
published from now on stays unpatched in it. #1227 moved here as a
stopgap when the free catalog was retired; this is the follow-up
discussed in #1574.

## What changed

- Default image is now `docker.io/postgres:17.10-trixie`
- Data directory moves to `/var/lib/postgresql/pgdata` — the official
  image has no `/bitnami` tree, and `PGDATA` has to be a subdirectory
  the container user creates itself, since `/var/lib/postgresql` and
  its data subdirectory ship `1777`, which Postgres rejects. Volume
  mount path moves accordingly.
- No template changes needed — the subchart drives the image through
  `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB`/`PGDATA`, all
  honored by `docker.io/postgres`.
- README documents the migration path for existing deployments with
  persistence enabled — in-place PVC reuse does not work, since Bitnami
  keeps `postgresql.conf`/`pg_hba.conf` outside the data directory and
  its image was built against a different glibc, so a dump and restore
  is required.
- CHANGELOG entry under Security.

## Test plan

Verified on a local kind cluster (deleted after testing):

- [x] `helm lint` clean
- [x] Fresh install, persistence disabled (default) — pods Ready
- [x] Fresh install, persistence enabled — data survives pod delete/restart
- [x] Migrations apply (18 tables, seeded "Flatcar Container Linux" app)
- [x] `/health` returns 200
- [x] Omaha `/v1/update` returns a real package manifest
- [x] Non-default `postgresql.auth.username` variant works