### PR TITLE
test(metrics): add unit tests for getMetricsRefreshInterval

### DIFF
--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMetricsRefreshInterval(t *testing.T) {
+	testCases := []struct {
+		name        string
+		envValue    string
+		expectedDur time.Duration
+	}{
+		{
+			name:        "default when env var is not set",
+			envValue:    "",
+			expectedDur: defaultMetricsUpdateInterval,
+		},
+		{
+			name:        "valid custom interval",
+			envValue:    "30s",
+			expectedDur: 30 * time.Second,
+		},
+		{
+			name:        "valid custom interval in minutes",
+			envValue:    "2m",
+			expectedDur: 2 * time.Minute,
+		},
+		{
+			name:        "fallback on invalid format",
+			envValue:    "invalid-duration",
+			expectedDur: defaultMetricsUpdateInterval,
+		},
+		{
+			name:        "fallback on negative duration",
+			envValue:    "-10s",
+			expectedDur: defaultMetricsUpdateInterval,
+		},
+		{
+			name:        "fallback on zero duration",
+			envValue:    "0s",
+			expectedDur: defaultMetricsUpdateInterval,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue == "" {
+				os.Unsetenv("NEBRASKA_METRICS_UPDATE_INTERVAL")
+			} else {
+				os.Setenv("NEBRASKA_METRICS_UPDATE_INTERVAL", tc.envValue)
+			}
+			defer os.Unsetenv("NEBRASKA_METRICS_UPDATE_INTERVAL")
+
+			interval := getMetricsRefreshInterval()
+			assert.Equal(t, tc.expectedDur, interval)
+		})
+	}
+}


### PR DESCRIPTION
# test(metrics): add unit tests for getMetricsRefreshInterval

This PR adds unit tests for `getMetricsRefreshInterval()` in the `backend/pkg/metrics` package. Currently, the metrics package does not have test coverage for environment variable parsing.

The tests cover all parsing scenarios and fallback behaviors:
- Default fallback when `NEBRASKA_METRICS_UPDATE_INTERVAL` is unset
- Valid custom intervals in seconds and minutes (e.g., `30s`, `2m`)
- Fallback handling when invalid duration strings, negative durations, or zero durations are passed

## How to use

Reviewers can validate this change by running the Go test suite inside the `backend` package.

## Testing done

- Formatted code using `go fmt ./pkg/metrics/...`
- Ran the unit test suite locally:
```bash
cd backend
go test -v ./pkg/metrics/...