### PR TITLE
fix(api): validate blacklist channel arch on package update

### DIFF
--- a/backend/pkg/api/admin/packages.go
+++ b/backend/pkg/api/admin/packages.go
@@ -336,6 +336,10 @@ func (s *Service) DeletePackage(pkgID string) error {
 // called, the package has already been updated except for the channels
 // blacklist, that may happen here if needed.
 func (s *Service) updatePackageBlacklistedChannels(tx *sqlx.Tx, pkg *types.Package, oldPkg *types.Package) error {
+	if err := s.checkMatchingArch(pkg.ChannelsBlacklist, pkg.Arch); err != nil {
+		return err
+	}
+
 	pkgUpdated := oldPkg
 
 	newChannelsBlacklist := make(map[string]struct{}, len(pkg.ChannelsBlacklist))

--- a/backend/pkg/api/packages_test.go
+++ b/backend/pkg/api/packages_test.go
@@ -135,6 +135,41 @@ func TestUpdatePackage(t *testing.T) {
 	assert.Equal(t, types.ArchAll, pkg.Arch)
 }
 
+func TestUpdatePackageArchMismatch(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	tTeam, _ := as.AddTeam(&types.Team{Name: "test_team"})
+	tApp, _ := as.AddApp(&types.Application{Name: "test_app", TeamID: tTeam.ID})
+	tChannel, _ := as.AddChannel(&types.Channel{
+		Name:          "arm_channel",
+		Color:         "blue",
+		ApplicationID: tApp.ID,
+		Arch:          types.ArchAArch64,
+	})
+
+	tPkg, err := as.AddPackage(&types.Package{
+		Type:          types.PkgTypeOther,
+		URL:           "http://sample.url/pkg",
+		Version:       "1.0.0",
+		ApplicationID: tApp.ID,
+		Arch:          types.ArchAMD64,
+	})
+	assert.NoError(t, err)
+
+	err = as.UpdatePackage(&types.Package{
+		ID:                tPkg.ID,
+		Type:              types.PkgTypeOther,
+		URL:               "http://sample.url/pkg",
+		Version:           "1.0.1",
+		ApplicationID:     tApp.ID,
+		Arch:              types.ArchAMD64,
+		ChannelsBlacklist: []string{tChannel.ID},
+	})
+	assert.Equal(t, types.ErrArchMismatch, err)
+}
+
 func TestUpdatePackageFlatcar(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()


### PR DESCRIPTION
## Summary

Package updates did not validate the architecture of newly blacklisted channels. As a result, an `amd64` package could be updated with an `aarch64` channel in its blacklist, even though package creation already rejected the same mismatch.

This change calls the existing `checkMatchingArch` validation from `updatePackageBlacklistedChannels` before blacklist entries are inserted and adds regression coverage for the update path.

Tracking issue: [flatcar/nebraska#1596](https://github.com/flatcar/nebraska/issues/1596)

## Tests

The following checks pass:

```text
NEBRASKA_DB_URL=postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10 go test ./pkg/api/... -run '^TestUpdatePackageArchMismatch$' -count=1 -v
NEBRASKA_DB_URL=postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10 go test -p 1 ./pkg/api/... -count=1
go vet ./pkg/api/...
```