### PR TITLE
fix(metrics): reset gauge vectors on recalculation to clear stale metrics

### DIFF
--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -135,6 +135,7 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get app instances per channel metrics: %w", err)
 	}
 
+	appInstancePerChannelGaugeMetric.Reset()
 	for _, metric := range aipcMetrics {
 		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName).Set(float64(metric.InstancesCount))
 	}
@@ -144,6 +145,7 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get failed update metrics: %w", err)
 	}
 
+	failedUpdatesGaugeMetric.Reset()
 	for _, metric := range fuMetrics {
 		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
 	}


### PR DESCRIPTION
# fix(metrics): reset gauge vectors on recalculation to clear stale metrics

In `backend/pkg/metrics/metrics.go`, `appInstancePerChannelGaugeMetric` and `failedUpdatesGaugeMetric` are updated via `WithLabelValues(...).Set(...)` whenever `calculateMetrics()` executes.

When an instance upgrades, gets deregistered, or an application/version combination is no longer returned by the database queries (`GetAppInstancesPerChannelMetrics` or `GetFailedUpdatesMetrics`), the Prometheus collector retains the previous label values indefinitely in memory.

This PR adds `.Reset()` calls on both `GaugeVec` collectors before setting fresh values so that stale time-series label combinations are properly cleared on each recalculation cycle.

## How to use

Reviewers can inspect `calculateMetrics()` in `backend/pkg/metrics/metrics.go` to verify that `appInstancePerChannelGaugeMetric.Reset()` and `failedUpdatesGaugeMetric.Reset()` are invoked prior to metric iteration.

## Testing done

- Ran `go fmt ./pkg/metrics/...` to ensure standard Go formatting.
- Verified compilation and static analysis using:
```bash
cd backend
go build ./pkg/metrics/...