### PR TITLE
feat(ui): add pagination to applications list

### DIFF
--- a/frontend/src/api/API.ts
+++ b/frontend/src/api/API.ts
@@ -30,8 +30,22 @@ function isNotNullUndefinedOrEmptyString(val: any) {
 }
 
 export default class API {
-  static getApplications(): Promise<WithCount<{ applications: Application[] }>> {
-    return API.getJSON(`${BASE_URL}/apps`);
+  static getApplications(queryOptions?: {
+    page?: number;
+    perpage?: number;
+  }): Promise<WithCount<{ applications: Application[] }>> {
+    const params = new URLSearchParams();
+    if (queryOptions) {
+      if (queryOptions.page !== undefined) {
+        params.append('page', String(queryOptions.page));
+      }
+      if (queryOptions.perpage !== undefined) {
+        params.append('perpage', String(queryOptions.perpage));
+      }
+    }
+    const queryStr = params.toString();
+    const url = `${BASE_URL}/apps${queryStr ? '?' + queryStr : ''}`;
+    return API.doRequest('GET', url);
   }
 
   static getApplication(applicationID: string): Promise<Application> {

--- a/frontend/src/components/Applications/ApplicationList.tsx
+++ b/frontend/src/components/Applications/ApplicationList.tsx
@@ -1,4 +1,4 @@
-import { List } from '@mui/material';
+import { List, TablePagination } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -20,15 +20,30 @@ export default function ApplicationList() {
     applicationsStore().getCachedApplications ? applicationsStore().getCachedApplications() : []
   );
 
+  const [totalCount, setTotalCount] = React.useState(
+    applicationsStore().getApplicationsTotalCount() || 0
+  );
+
   const onChange = React.useCallback(() => {
     setApplications(applicationsStore().getCachedApplications());
+    setTotalCount(applicationsStore().getApplicationsTotalCount());
   }, []);
+
+  const applicationsQueryParams = applicationsStore().getApplicationsQueryParams();
+
+  function handleChangePage(
+    _event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
+    newPage: number
+  ) {
+    applicationsStore().setApplicationsQueryParams({ ...applicationsQueryParams, page: newPage });
+  }
 
   React.useEffect(() => {
     // Get initial data in case store already has applications loaded
     const currentApplications = applicationsStore().getCachedApplications();
     if (currentApplications) {
       setApplications(currentApplications);
+      setTotalCount(applicationsStore().getApplicationsTotalCount());
     }
 
     // Set up listener for future changes
@@ -40,12 +55,26 @@ export default function ApplicationList() {
     };
   }, [onChange]);
 
-  return <ApplicationListPure applications={applications} loading={applications === null} />;
+  return (
+    <ApplicationListPure
+      applicationsQueryParams={applicationsQueryParams}
+      handleChangePage={handleChangePage}
+      applications={applications}
+      loading={applications === null}
+      applicationsTotalCount={totalCount}
+    />
+  );
 }
 
 export interface ApplicationListPureProps {
   /** To show. */
   applications: null | Application[];
+
+  applicationsTotalCount?: number;
+
+  applicationsQueryParams?: { perPage: number; page: number };
+
+  handleChangePage?: (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => void;
   /** If we are waiting for applications to load. */
   loading?: boolean;
   /** If the edit screen is open for editId */
@@ -124,18 +153,36 @@ export function ApplicationListPure(props: ApplicationListPureProps) {
         ]}
       />
       <Paper>
-        <List
-          sx={{
-            '& > hr:first-of-type': {
-              display: 'none',
-            },
-          }}
-        >
-          {entries}
-        </List>
-        {appToUpdate && (
-          <ApplicationEdit data={appToUpdate} show={editOpen} onHide={closeUpdateAppModal} />
-        )}
+        <React.Fragment>
+          <List
+            sx={{
+              '& > hr:first-of-type': {
+                display: 'none',
+              },
+            }}
+          >
+            {entries}
+          </List>
+          {appToUpdate && (
+            <ApplicationEdit data={appToUpdate} show={editOpen} onHide={closeUpdateAppModal} />
+          )}
+          {props.handleChangePage && props.applicationsQueryParams && (
+            <TablePagination
+              rowsPerPageOptions={[]}
+              component="div"
+              count={props.applicationsTotalCount ?? props.applications?.length ?? 0}
+              rowsPerPage={props.applicationsQueryParams.perPage}
+              page={props.applicationsQueryParams.page}
+              backIconButtonProps={{
+                'aria-label': t('frequent|previous_page'),
+              }}
+              nextIconButtonProps={{
+                'aria-label': t('frequent|next_page'),
+              }}
+              onPageChange={props.handleChangePage}
+            />
+          )}
+        </React.Fragment>
       </Paper>
     </>
   );

--- a/frontend/src/stores/ApplicationsStore.ts
+++ b/frontend/src/stores/ApplicationsStore.ts
@@ -7,16 +7,26 @@ import { setUser } from './redux/features/user';
 import store from './redux/store';
 
 type PackageQueryParams = { page: number; perPage: number };
+type ApplicationsQueryParams = { page: number; perPage: number };
 
 class ApplicationsStore extends Store {
   applications: Application[];
+  applicationsTotalCount: number;
   packageQueryParams: PackageQueryParams;
+  applicationsQueryParams: ApplicationsQueryParams;
+
   interval: null | number;
   constructor() {
     super();
     this.applications = [];
+    this.applicationsTotalCount = 0;
     this.interval = null;
     this.packageQueryParams = { page: 0, perPage: 10 };
+    this.applicationsQueryParams = { page: 0, perPage: 10 };
+  }
+
+  getApplicationsTotalCount() {
+    return this.applicationsTotalCount;
   }
 
   // Applications
@@ -25,9 +35,19 @@ class ApplicationsStore extends Store {
     return this.packageQueryParams;
   }
 
+  getApplicationsQueryParams() {
+    return { ...this.applicationsQueryParams };
+  }
+
   setPackageQueryParams(params: PackageQueryParams, applicationID: string) {
     this.packageQueryParams = params;
     this.getAndUpdatePackages(applicationID);
+  }
+
+  setApplicationsQueryParams(params: ApplicationsQueryParams) {
+    this.applicationsQueryParams = params;
+    this.emitChange();
+    this.getApplications();
   }
 
   getCachedApplications() {
@@ -50,15 +70,22 @@ class ApplicationsStore extends Store {
       }, 60 * 1000);
     }
 
-    API.getApplications()
+    const applicationsQueryParams = {
+      perpage: this.applicationsQueryParams.perPage,
+      page: this.applicationsQueryParams.page + 1,
+    };
+
+    API.getApplications(applicationsQueryParams)
       .then(response => {
         this.applications = response.applications;
+        this.applicationsTotalCount = response.totalCount;
         this.emitChange();
       })
       .catch(error => {
         switch (error.status) {
           case 404:
             this.applications = [];
+            this.applicationsTotalCount = 0;
             this.emitChange();
             break;
           case 401:
@@ -103,13 +130,9 @@ class ApplicationsStore extends Store {
     data: Pick<Application, 'name' | 'description' | 'product_id'>,
     clonedApplication: string
   ) {
-    const application = await API.createApplication(data, clonedApplication);
-    const applicationItem = application;
-    if (this.applications) {
-      this.applications.unshift(applicationItem);
-      this.applications = [...this.applications];
-      this.emitChange();
-    }
+    await API.createApplication(data, clonedApplication);
+    this.applicationsQueryParams = { ...this.applicationsQueryParams, page: 0 };
+    this.getApplications();
   }
 
   async updateApplication(applicationID: string, data: any) {
@@ -160,12 +183,15 @@ class ApplicationsStore extends Store {
   }
 
   deleteApplication(applicationID: string) {
-    API.deleteApplication(applicationID).then(() => {
-      this.applications = _.without(
-        this.applications as _.List<any>,
-        _.findWhere(this.applications as _.Collection<any>, { id: applicationID })
-      );
-      this.emitChange();
+    return API.deleteApplication(applicationID).then(() => {
+      const isLastItemOnPage = this.applications.length === 1;
+      if (isLastItemOnPage && this.applicationsQueryParams.page > 0) {
+        this.applicationsQueryParams = {
+          ...this.applicationsQueryParams,
+          page: this.applicationsQueryParams.page - 1,
+        };
+      }
+      this.getApplications();
     });
   }
 


### PR DESCRIPTION
Fixes #548

# Add pagination to applications list

## Summary
`GET /apps` supports pagination (page, perpage), but the frontend ignored both, fetching applications with no params silently truncating results past the backend's default page size. This adds pagination to the Applications list, mirroring the existing Packages list (`GET /apps/<appID>/packages`) for UI and code consistency.

## Changes
- `API.getApplications()` now accepts page/perpage query params
- `ApplicationsStore`: added `applicationsQueryParams` and `applicationsTotalCount` state; `createApplication` resets to page 0 on create; `deleteApplication` steps back a page when the last item on a non-first page is removed
- `ApplicationList`: integrated MUI `TablePagination`, wired to the store

## Testing done

- `npm run lint`, `npx tsc -b`
- `npm run test`  79/79 passing (no existing tests covered this area)
- Manually verified: requests append `?page=x&perpage=y`, pagination controls render/update correctly, deleting the last item on a non-first page steps back to the previous page