### PR TITLE
feat(frontend): add unlimited updates toggle to group policy form

### DIFF
--- a/frontend/src/components/Groups/GroupEditDialog/GroupEditDialog.tsx
+++ b/frontend/src/components/Groups/GroupEditDialog/GroupEditDialog.tsx
@@ -17,6 +17,7 @@ import * as Yup from 'yup';
 import { Group } from '../../../api/apiDataTypes';
 import { applicationsStore } from '../../../stores/Stores';
 import { DEFAULT_TIMEZONE } from '../../common/TimezonePicker';
+import { MAX_UPDATES_PER_TIME_PERIOD } from '../GroupItem';
 import GroupDetailsForm from './GroupDetailsForm';
 import GroupPolicyForm from './GroupPolicyForm';
 
@@ -68,7 +69,8 @@ export default function GroupEditDialog(props: GroupEditDialogProps) {
       policy_updates_enabled: values.updatesEnabled,
       policy_safe_mode: values.safeMode,
       policy_office_hours: values.onlyOfficeHours,
-      policy_max_updates_per_period: parseInt(values.maxUpdates),
+      policy_max_updates_per_period: values.updatesUnlimited 
+      ? Max_UPDATES_PER_TIME_PERIOD : parseInt(values.maxUpdates),
       policy_period_interval: updatesPeriodPolicy,
       policy_update_timeout: updatesTimeoutPolicy,
     };
@@ -188,7 +190,11 @@ export default function GroupEditDialog(props: GroupEditDialogProps) {
     name: maxCharacters(50, true).required(),
     track: maxCharacters(256),
     description: maxCharacters(250),
-    maxUpdates: positiveNum(),
+    maxUpdates: Yup.number(). when('updatesUnlimited', {
+      is: true,
+      then: schema => schema.notRequired(),
+      otherwise: () => positiveNum(),
+    }),
     updatesPeriodRange: positiveNum(),
     updatesTimeout: positiveNum(),
   });
@@ -205,6 +211,7 @@ export default function GroupEditDialog(props: GroupEditDialogProps) {
       track: '',
       appID: appID,
       maxUpdates: 1,
+      updatesUnlimited: false,
       updatesPeriodRange: 1,
       updatesPeriodUnit: 'hours',
       updatesTimeout: 1,
@@ -231,6 +238,7 @@ export default function GroupEditDialog(props: GroupEditDialogProps) {
       onlyOfficeHours: group.policy_office_hours,
       safeMode: group.policy_safe_mode,
       maxUpdates: group.policy_max_updates_per_period,
+      updatesUnlimited: group.policy_max_updates_per_period >= MAX_UPDATES_PER_TIME_PERIOD,
       channel: group.channel ? group.channel.id : '',
       updatesPeriodRange: currentUpdatesPeriodRange,
       updatesPeriodUnit: currentUpdatesPeriodUnit,

--- a/frontend/src/components/Groups/GroupEditDialog/GroupPolicyForm.tsx
+++ b/frontend/src/components/Groups/GroupEditDialog/GroupPolicyForm.tsx
@@ -117,6 +117,22 @@ export default function GroupPolicyForm(props: GroupPolicyFormProps) {
           </Grid>
         </Grid>
       </Box>
+      <Box mt={1}>
+        <FormControlLabel
+        label={t('groups|unlimited_updates_lower')}
+        control={
+          <Field
+            name="updatesUnlimited"
+            component={Switch}
+            color="primary"
+            checked={values.updatesUnlimited}
+            onChange={(e: any) => {
+              setFieldValue('updatesUnlimited', e.target.checked);
+            }}
+          />
+          }
+        />
+        </Box>
       <Box my={2}>
         <Grid container spacing={2} justifyContent="space-between" alignItems="center" size={12}>
           <Grid size={5}>
@@ -129,7 +145,8 @@ export default function GroupPolicyForm(props: GroupPolicyFormProps) {
                 margin="dense"
                 type="number"
                 fullWidth
-                inputProps={{ min: 0 }}
+                disabled={values.updatesUnlimited}
+                inputProps={{ min: 1 }}
               />
             </Box>
           </Grid>

--- a/frontend/src/components/Groups/GroupItem.tsx
+++ b/frontend/src/components/Groups/GroupItem.tsx
@@ -20,7 +20,7 @@ import MoreMenu from '../common/MoreMenu';
 import VersionProgressBar from '../common/VersionBreakdownBar';
 
 // From this number, we stop rate limiting in the backend
-const MAX_UPDATES_PER_TIME_PERIOD = 900000;
+export const MAX_UPDATES_PER_TIME_PERIOD = 900000;
 
 export function formatUpdateLimits(t: TFunction, group: Group) {
   if (group.policy_max_updates_per_period >= MAX_UPDATES_PER_TIME_PERIOD) {

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -21,6 +21,7 @@
   "safe_mode_lower": "Safe mode",
   "status_breakdown": "Status Breakdown",
   "track_identifier": "Track (identifier for clients, filled with the group ID if omitted)",
+  "unlimited_updates_lower": "Unlimited updates", 
   "update_policy_unlimited": "Unlimited number of parallel updates",
   "update": "Update",
   "update_limits": "Update Limits",


### PR DESCRIPTION
Adds an 'Unlimited updates' switch to the group edit dialog's Policy tab, so unlimited updates no longer require knowing to type 999999 into the max-updates field manually. The number field disables itself when the switch is on.

Fixes #265