### PR TITLE
backend/pkg/api: make instance stats queries timezone independent

### DIFF
--- a/backend/pkg/api/instances_test.go
+++ b/backend/pkg/api/instances_test.go
@@ -374,3 +374,63 @@ func TestUpdateInstanceStatsNoArch(t *testing.T) {
 	assert.Equal(t, "1.0.0", instanceStats[0].Version)
 	assert.Equal(t, 1, instanceStats[0].Instances)
 }
+
+func TestUpdateInstanceStatsTimezone(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	defer func() {
+		_, _ = a.db().Exec("SET TIME ZONE 'UTC'")
+	}()
+	_, _ = a.db().Exec("TRUNCATE instance_stats")
+
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+
+	tTeam, _ := as.AddTeam(&types.Team{Name: "test_team_tz"})
+	tApp, _ := as.AddApp(&types.Application{Name: "test_app_tz", TeamID: tTeam.ID})
+	tPkg, _ := as.AddPackage(&types.Package{Type: types.PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID, Arch: types.ArchAMD64})
+	tChannel, _ := as.AddChannel(&types.Channel{Name: "test_channel_tz", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID), Arch: types.ArchAMD64})
+	tGroup, _ := as.AddGroup(&types.Group{Name: "group_tz", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	_, _ = rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, runtime.NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+
+	// Use deterministic end of day UTC timestamp for today
+	now := time.Now().UTC()
+	ts := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
+	elapsed := 48 * time.Hour
+
+	// 1. Run under UTC session timezone
+	_, err := a.db().Exec("SET TIME ZONE 'UTC'")
+	assert.NoError(t, err)
+
+	err = rs.UpdateInstanceStats(&ts, &elapsed)
+	assert.NoError(t, err)
+
+	utcStats, err := a.GetInstanceStatsByTimestamp(ts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, utcStats)
+
+	// 2. Run queries under non-UTC session timezone (America/New_York)
+	_, err = a.db().Exec("SET TIME ZONE 'America/New_York'")
+	assert.NoError(t, err)
+
+	nyStats, err := a.GetInstanceStatsByTimestamp(ts)
+	assert.NoError(t, err)
+	assert.Equal(t, utcStats, nyStats)
+
+	// 3. Update stats under America/New_York session timezone and verify timestamp consistency
+	ts2 := ts.Add(24 * time.Hour)
+	err = rs.UpdateInstanceStats(&ts2, &elapsed)
+	assert.NoError(t, err)
+
+	nyStats2, err := a.GetInstanceStatsByTimestamp(ts2)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, nyStats2)
+
+	// Reset timezone to UTC to fetch baseline comparison for ts2
+	_, err = a.db().Exec("SET TIME ZONE 'UTC'")
+	assert.NoError(t, err)
+
+	utcStats2, err := a.GetInstanceStatsByTimestamp(ts2)
+	assert.NoError(t, err)
+	assert.Equal(t, utcStats2, nyStats2)
+}

--- a/backend/pkg/api/internal/dbreads/instances.go
+++ b/backend/pkg/api/internal/dbreads/instances.go
@@ -333,6 +333,9 @@ func (q *Queries) InstanceStatsQuery(t *time.Time, duration *time.Duration) *goq
 	if t == nil {
 		now := time.Now().UTC()
 		t = &now
+	} else {
+		utc := t.UTC()
+		t = &utc
 	}
 
 	if duration == nil {
@@ -375,8 +378,8 @@ func (q *Queries) InstanceStatsQuery(t *time.Time, duration *time.Duration) *goq
 	}
 
 	interval := durationToInterval(*duration)
-	timestamp := goqu.L("timestamp ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")))
-	timestampMinusDuration := goqu.L("timestamp ? - interval ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")), interval)
+	timestamp := goqu.L("timestamptz ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")))
+	timestampMinusDuration := goqu.L("timestamptz ? - interval ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")), interval)
 
 	query := goqu.From(goqu.T("instance_application")).
 		Select(
@@ -436,7 +439,8 @@ func (q *Queries) GetInstanceStats() ([]types.InstanceStats, error) {
 // GetInstanceStatsByTimestamp returns an InstanceStats array of instances matching a
 // given timestamp value, ordered by version.
 func (q *Queries) GetInstanceStatsByTimestamp(t time.Time) ([]types.InstanceStats, error) {
-	timestamp := goqu.L("timestamp ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t = t.UTC()
+	timestamp := goqu.L("timestamptz ?", goqu.V(t.Format("2006-01-02T15:04:05.999999Z07:00")))
 
 	query, _, err := goqu.From("instance_stats").
 		Where(goqu.C("timestamp").Eq(timestamp)).


### PR DESCRIPTION
### Summary of Changes
Fixes a PostgreSQL database session timezone sensitivity issue in Nebraska's `instance_stats` functionality (`InstanceStatsQuery` and `GetInstanceStatsByTimestamp`).

### Problem
`InstanceStatsQuery` and `GetInstanceStatsByTimestamp` constructed SQL expressions formatted as `timestamp '...'`. In PostgreSQL SQL syntax, `timestamp '...'` casts string literals to `timestamp` (without time zone). When the database session timezone was set to a non-UTC location (e.g. `America/New_York`), PostgreSQL implicitly converted the naive timestamp to `timestamptz` using the session `TimeZone`, shifting query boundaries and returning 0 or incomplete results.

### Solution
1. **Normalized Timestamp Inputs**: Normalize Go `time.Time` values to UTC (`.UTC()`) at function boundaries in `InstanceStatsQuery` and `GetInstanceStatsByTimestamp`.
2. **Timezone-Aware SQL Literals**: Replaced `timestamp ?` with `timestamptz ?` in `goqu` expressions for `timestamp` and `timestampMinusDuration`. `timestamptz '...'` forces PostgreSQL to parse the literal as an absolute UTC epoch instant regardless of session timezone.
3. **Regression Test**: Added `TestUpdateInstanceStatsTimezone` in `backend/pkg/api/instances_test.go` to verify query equivalence across UTC and `America/New_York` session timezones.

### Testing
- `go test -count=1 -v ./pkg/api -run 'TestUpdateInstanceStats'` (Passed)
- `go test -v ./pkg/api` (Passed)
- `go test -cover ./pkg/api` (Passed - 80.0%)
