### PR TITLE
docs: fix typo in README and restructure frontend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To learn more about the Omaha protocol, please refer to the upstream docs [here]
 - Store and serve Flatcar Container Linux payloads (optional);
 - Compatible with any applications that use the Omaha protocol;
 - Define groups, channels, and packages;
-- Control what updates are rolled out for which instance groups, as well as when and how they are updates;
+- Control what updates are rolled out for which instance groups, as well as when and how they are updated;
 - Pause/resume updates at any time;
 - Statistics about the versions installed for instances, status history, and updates progress, etc.;
 - Activity timeline to quickly see important events or errors;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,12 +13,22 @@
 
 ## Getting Started
 
-```bash
-# Install dependencies
-npm install
+### Prerequisites
 
-# Development
-## Start the backend
+- Node.js
+- Docker (for the backend database)
+- `psql` client (PostgreSQL CLI)
+
+### Install dependencies
+
+```bash
+npm install
+```
+
+## Development
+
+### Start the backend
+
 ```bash
 docker run --rm -d --name nebraska-postgres-dev -p 5432:5432 -e POSTGRES_PASSWORD=nebraska postgres && \
     sleep 10 && \
@@ -26,31 +36,58 @@ docker run --rm -d --name nebraska-postgres-dev -p 5432:5432 -e POSTGRES_PASSWOR
     psql postgres://postgres:nebraska@localhost:5432/nebraska -c 'set timezone = "utc";'
 make run-backend
 ```
-## Run development server
+
+### Run the development server
+
+```bash
 npm run dev
+```
 
-# Run tests
-## To run vitests
+## Testing
+
+### Run unit tests (Vitest)
+
+```bash
 npm test
+```
 
-## To update storybook snapshots
+### Update Storybook snapshots
+
+```bash
 npm run build-storybook:ci && npm run serve-storybook:ci
 npm run test-storybook:ci -- -u
+```
 
-## [E2E Playwright tests](./e2e/README.md)
+### [E2E Playwright tests](./e2e/README.md)
 
-## Generate test coverage report
+### Generate test coverage report
+
+```bash
 npm run test:coverage
+```
 
-## Run linter and formatter
+## Linting & Formatting
+
+```bash
 npm run lint
+```
+
+```bash
 npm run format
+```
 
-# Build for production
+## Production Build
+
+```bash
 npm run build
+```
 
-# Run Storybook
+## Storybook
+
+```bash
+# Run Storybook locally
 npm run storybook
 
-# Build Storybook
+# Build static Storybook
 npm run build-storybook
+```


### PR DESCRIPTION
## What this PR does

Two small documentation fixes:

1. **Main README** — Fixed a typo in the Features section: "how they are updates" → "how they are updated"

2. **Frontend README** — Restructured the getting started section. The nested code blocks (triple backticks inside triple backticks) weren't rendering properly on GitHub, making the setup instructions hard to follow. Separated them into distinct sections with proper headings.

No code changes, just docs.