### PR TITLE
fix(frontend): preserve raw SemVer strings with build metadata in version timeline

### DIFF
--- a/frontend/src/__tests__/Groups/VersionCountTimeline.spec.tsx
+++ b/frontend/src/__tests__/Groups/VersionCountTimeline.spec.tsx
@@ -1,0 +1,135 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Group } from '../../api/apiDataTypes';
+import VersionCountTimeline from '../../components/Groups/GroupCharts/VersionCountTimeline';
+import themes from '../../lib/themes';
+import GroupChartsStore from '../../stores/GroupChartsStore';
+import { groupChartStoreContext } from '../../stores/Stores';
+
+describe('VersionCountTimeline Component', () => {
+  const mockGroup: Group = {
+    id: 'test-group-id',
+    name: 'Test Group',
+    description: 'Test Group Description',
+    created_ts: '2026-01-01T00:00:00Z',
+    rollout_in_progress: false,
+    application_id: 'test-app-id',
+    channel_id: 'test-channel-id',
+    policy_updates_enabled: true,
+    policy_safe_mode: false,
+    policy_office_hours: false,
+    policy_timezone: 'UTC',
+    policy_period_interval: '15m',
+    policy_max_updates_per_period: 10,
+    policy_update_timeout: '1h',
+    channel: {
+      id: 'test-channel-id',
+      name: 'test-channel',
+      color: '#14b9d6',
+      created_ts: '2026-01-01T00:00:00Z',
+      application_id: 'test-app-id',
+      package_id: 'test-pkg-id',
+      package: {
+        id: 'test-pkg-id',
+        type: 1,
+        version: '3510.2.0+test',
+        url: '',
+        filename: '',
+        description: '',
+        size: '100',
+        hash: '',
+        created_ts: '2026-01-01T00:00:00Z',
+        channels_blacklist: null,
+        application_id: 'test-app-id',
+        arch: 1,
+        extra_files: [],
+      },
+      arch: 1,
+    },
+    track: 'test-channel',
+  };
+
+  const duration = { displayValue: '1 day', queryValue: '1d', disabled: false };
+
+  it('renders build metadata versions with correct count and percentage in table', async () => {
+    const mockTimeline = {
+      '2026-08-15T00:00:00Z': {
+        '3510.2.0+test': 7,
+        '2191.5.0': 3,
+      },
+      '2026-08-15T01:00:00Z': {
+        '3510.2.0+test': 7,
+        '2191.5.0': 3,
+      },
+    };
+
+    class GroupChartsStoreMock extends GroupChartsStore {
+      async getGroupVersionCountTimeline() {
+        return mockTimeline;
+      }
+    }
+
+    const ChartStoreContext = groupChartStoreContext();
+
+    render(
+      <ChartStoreContext.Provider value={new GroupChartsStoreMock()}>
+        <MemoryRouter>
+          <ThemeProvider theme={themes['light']}>
+            <VersionCountTimeline group={mockGroup} duration={duration} isAnimationActive={false} />
+          </ThemeProvider>
+        </MemoryRouter>
+      </ChartStoreContext.Provider>
+    );
+
+    // Wait for the version table to render with the raw version containing build metadata
+    await waitFor(() => {
+      expect(screen.getByText('3510.2.0+test')).toBeTruthy();
+    });
+
+    expect(screen.getByText('2191.5.0')).toBeTruthy();
+    expect(screen.getAllByText('7').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('70.0')).toBeTruthy();
+    expect(screen.getByText('30.0')).toBeTruthy();
+  });
+
+  it('distinguishes multiple metadata variants of the same core version', async () => {
+    const mockTimeline = {
+      '2026-08-15T00:00:00Z': {
+        '1.2.3+aws': 4,
+        '1.2.3+azure': 6,
+      },
+    };
+
+    class GroupChartsStoreMock extends GroupChartsStore {
+      async getGroupVersionCountTimeline() {
+        return mockTimeline;
+      }
+    }
+
+    const ChartStoreContext = groupChartStoreContext();
+
+    render(
+      <ChartStoreContext.Provider value={new GroupChartsStoreMock()}>
+        <MemoryRouter>
+          <ThemeProvider theme={themes['light']}>
+            <VersionCountTimeline group={mockGroup} duration={duration} isAnimationActive={false} />
+          </ThemeProvider>
+        </MemoryRouter>
+      </ChartStoreContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('1.2.3+aws')).toBeTruthy();
+      expect(screen.getByText('1.2.3+azure')).toBeTruthy();
+    });
+
+    expect(screen.getAllByText('4').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('6').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('40.0')).toBeTruthy();
+    expect(screen.getByText('60.0')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/utils/helpers.spec.ts
+++ b/frontend/src/__tests__/utils/helpers.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
+import { Channel } from '../../api/apiDataTypes';
+import { theme } from '../../TestHelpers/theme';
 import * as helpers from '../../utils/helpers';
 
 describe('Utility Functions', () => {
@@ -24,5 +26,44 @@ describe('Utility Functions', () => {
     const [errorMessages, flags] = helpers.getErrorAndFlags(3);
     expect(errorMessages).toContain('OmahaResponseHandlerError');
     expect(flags).toEqual([]);
+  });
+
+  describe('makeColorsForVersions', () => {
+    test('assigns colors keyed by raw version strings without metadata', () => {
+      const versions = ['2191.5.0', '2247.2.0'];
+      const colors = helpers.makeColorsForVersions(theme, versions, null);
+      expect(Object.keys(colors)).toContain('2191.5.0');
+      expect(Object.keys(colors)).toContain('2247.2.0');
+      expect(colors['2191.5.0']).toBeDefined();
+      expect(colors['2247.2.0']).toBeDefined();
+    });
+
+    test('assigns colors keyed by raw version strings with build metadata', () => {
+      const versions = ['3510.2.0+test', '2191.5.0'];
+      const colors = helpers.makeColorsForVersions(theme, versions, null);
+      expect(colors['3510.2.0+test']).toBeDefined();
+      expect(colors['2191.5.0']).toBeDefined();
+      expect(colors['3510.2.0']).toBeUndefined();
+    });
+
+    test('highlights channel package version with primary theme color for metadata versions', () => {
+      const mockChannel = {
+        package: {
+          version: '3510.2.0+test',
+        },
+      } as Channel;
+      const versions = ['3510.2.0+test', '2191.5.0'];
+      const colors = helpers.makeColorsForVersions(theme, versions, mockChannel);
+      expect(colors['3510.2.0+test']).toBe(theme.palette.primary.main);
+      expect(colors['2191.5.0']).not.toBe(theme.palette.primary.main);
+    });
+
+    test('assigns distinct colors for multiple metadata variants of the same core version', () => {
+      const versions = ['1.2.3+aws', '1.2.3+azure'];
+      const colors = helpers.makeColorsForVersions(theme, versions, null);
+      expect(colors['1.2.3+aws']).toBeDefined();
+      expect(colors['1.2.3+azure']).toBeDefined();
+      expect(colors['1.2.3+aws']).not.toBe(colors['1.2.3+azure']);
+    });
   });
 });

--- a/frontend/src/components/Groups/GroupCharts/VersionCountTimeline.tsx
+++ b/frontend/src/components/Groups/GroupCharts/VersionCountTimeline.tsx
@@ -78,13 +78,15 @@ export default function VersionCountTimeline(props: VersionCountTimelineProps) {
       const cleanedVersion = cleanSemverVersion(version);
       // Discard any invalid versions (empty strings, etc.)
       if (semver.valid(cleanedVersion)) {
-        versions.push(cleanedVersion);
+        versions.push(version);
       }
     });
 
     // Sort versions (earliest first)
     versions.sort((version1, version2) => {
-      return semver.compare(version1, version2);
+      const cmp = semver.compare(cleanSemverVersion(version1), cleanSemverVersion(version2));
+      if (cmp !== 0) return cmp;
+      return version1.localeCompare(version2);
     });
 
     return versions;
@@ -106,10 +108,10 @@ export default function VersionCountTimeline(props: VersionCountTimelineProps) {
     // let's populate it from the selected time one.
     if (version_breakdown.length === 0 && selectedEntryPoint > -1) {
       // Create the version breakdown from the timeline
-      const entries = timelineChartData.data[selectedEntryPoint] || [];
+      const entries = timelineChartData.data[selectedEntryPoint] || {};
 
       for (const version of timelineChartData.keys) {
-        const versionCount = entries[version];
+        const versionCount = entries[version] || 0;
 
         total += versionCount;
 

--- a/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
+++ b/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { Channel } from '../../../api/apiDataTypes';
-import { cleanSemverVersion, makeColorsForVersions } from '../../../utils/helpers';
+import { makeColorsForVersions } from '../../../utils/helpers';
 
 const PREFIX = 'VersionProgressBar';
 
@@ -118,23 +118,13 @@ function VersionProgressBar(props: { version_breakdown: any; channel: Channel | 
     const versionsSorted = Object.keys(data).sort((version1, version2) => {
       // If the version is the channel's one, then it should come first.
       // If it's the 'Other', then it should come last.
-      // Otherwise compare the number of instances.
-      const cleanVersion1 = cleanSemverVersion(version1);
-      const cleanVersion2 = cleanSemverVersion(version2);
-      const results: { [key: string]: number } = { cleanVersion1: -1, cleanVersion2: 1 };
+      // Otherwise compare the percentages.
+      if (version1 === lastVersionChannel) return -1;
+      if (version2 === lastVersionChannel) return 1;
+      if (version1 === otherVersionLabel) return 1;
+      if (version2 === otherVersionLabel) return -1;
 
-      for (const version of [cleanVersion1, cleanVersion2]) {
-        switch (version) {
-          case lastVersionChannel:
-            return results[version];
-          case otherVersionLabel:
-            return -results[version];
-          default:
-            break;
-        }
-      }
-
-      return data[cleanVersion1] - data[cleanVersion2];
+      return (data[version1] || 0) - (data[version2] || 0);
     });
 
     data['key'] = 'version_breakdown';

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -102,17 +102,16 @@ export function makeColorsForVersions(
   let latestVersion = null;
 
   if (channel && channel.package) {
-    latestVersion = cleanSemverVersion(channel.package.version);
+    latestVersion = channel.package.version;
   }
 
   for (let i = versions.length - 1; i >= 0; i--) {
     const version = versions[i];
-    const cleanVersion = cleanSemverVersion(version);
 
-    if (cleanVersion === latestVersion) {
-      versionColors[cleanVersion] = theme.palette.primary.main;
+    if (version === latestVersion) {
+      versionColors[version] = theme.palette.primary.main;
     } else {
-      versionColors[cleanVersion] = colors[colorIndex++ % colors.length];
+      versionColors[version] = colors[colorIndex++ % colors.length];
     }
   }
 


### PR DESCRIPTION
# fix(frontend): preserve raw SemVer strings with build metadata in version timeline reporting

This PR resolves issue #1588 where the group **version timeline** chart and version breakdown table silently displayed blank instance counts and `0.0%` for valid SemVer versions containing build metadata (e.g. `3510.2.0+test`, `1.2.3+aws`), even when the backend API returned real instance counts for those versions.

The root cause was an internal key mismatch: the raw API timeline object is keyed by the raw version string (e.g. `3510.2.0+test`), but `getVersionsFromTimeline()` stripped build metadata via `cleanSemverVersion()`, pushing the cleaned string (`3510.2.0`) as the Recharts `dataKey` and table lookup key. Because the keys did not match the data object properties, Recharts drew no series, `getInstanceCount()` looked up `undefined` values, and `total` became `NaN`. Furthermore, `makeColorsForVersions()` keyed color mappings by the cleaned string, causing color mismatches and palette collisions for metadata variants sharing the same core version.

To fix this, we preserve the raw version string as the immutable identity key across `VersionCountTimeline` and `makeColorsForVersions`, while using `cleanSemverVersion()` solely for `semver.valid()` filtering and `semver.compare()` precedence sorting (with a `localeCompare` tiebreak for identical SemVer precedence). We also fixed the `VersionBreakdownBar` sort comparator to compare raw keys directly and added comprehensive unit and component tests.

## How to use

Reviewers can validate this PR using either the automated test suite or manual UI verification:

### Method 1: Automated Unit & Component Tests
Run the test suite to verify the new test suites for `makeColorsForVersions` and `VersionCountTimeline`:
```sh
cd frontend
npm test
```

### Method 2: Manual UI Verification
1. Start the Nebraska frontend development server:
   ```sh
   cd frontend
   npm run dev
   ```
2. Navigate to a group dashboard that has packages/instances with build metadata (e.g., `3510.2.0+test`).
3. Verify that:
   - The **Version timeline** chart renders the series line/area with the correct color matching the palette.
   - The **Version breakdown table** displays the full version string `3510.2.0+test`, the correct instance count, and the computed percentage.
   - Groups with standard versions (e.g. `2191.5.0`) continue to render identically without regressions.

## Testing done

Executed the complete frontend test suite, linter/formatter, and production build checks locally:

1. **Unit and Component Tests (`vitest`)**:
   ```zsh
   cd frontend && npm test
   ```
   **Output:**
   ```
   > Nebraska@0.1.0 test
   > cross-env TEST_TZ=true vitest --silent

    RUN  v4.1.10 /home/alronova/DevZone/OSS/Nebraska/frontend

    Test Files  21 passed (21)
         Tests  85 passed (85)
      Duration  6.00s
   ```

2. **Linting and Formatting Check (`eslint` + `prettier`)**:
   ```zsh
   cd frontend && npm run lint
   ```
   **Output:**
   ```
   All matched files use Prettier code style!
   (Exited with code 0, 0 errors, 0 warnings)
   ```

3. **TypeScript Compilation & Production Build (`tsc` + `vite build`)**:
   ```zsh
   cd frontend && npm run build
   ```
   **Output:**
   ```
   > Nebraska@0.1.0 build
   > tsc -b && vite build

   vite v8.2.0 building client environment for production...
   ✓ 2426 modules transformed.
   rendering chunks (1)...computing gzip size...
   dist/index.html                    0.98 kB │ gzip:   0.51 kB
   dist/assets/index-BCksz3io.js  2,332.12 kB │ gzip: 523.58 kB
   ✓ built in 1.01s
   ```
4. **Verified the fix via UI**
Before the fix:
<img width="1863" height="972" alt="Screenshot From 2026-08-19 03-01-53" src="https://github.com/user-attachments/assets/9a70553c-9135-4954-be8c-eda5652e214f" />

After the fix:
<img width="1863" height="972" alt="Screenshot From 2026-08-19 03-57-02" src="https://github.com/user-attachments/assets/a002905d-1ca6-46ca-bcb8-63890fe9e447" />

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
- [x] This PR fixes #1588
- [x] Commits are signed-off
- [x] Backward compatibility is maintained
<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
