### PR TITLE
charts/nebraska: stop shipping a hardcoded default database password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+
+- **helm/postgresql: remove the shipped default database password:** `postgresql.auth.postgresPassword` was hardcoded to `changeIt`. Any install that didn't override it deployed with that literal, published string as the database administrator password. The default is now empty, which the bitnami subchart treats as "generate a random password and store it in the `<release>-postgresql` secret" — installs now get a unique credential with no operator action required.
+
 ### Added
 
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -212,7 +212,7 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 |----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------|
 | `postgresql.enabled`                                     | Enable Bitnami postgresql subchart and deploy database within this helm release                               | `true`                 |
 | `postgresql.auth.database`                               | PostgreSQL database                                                                                           | `nebraska`             |
-| `postgresql.auth.postgresPassword`                       | PostgreSQL password of user "postgres" **Recommended to change it to something secure for security reasons.** | `changeIt`             |
+| `postgresql.auth.postgresPassword`                       | PostgreSQL password of user "postgres". Left empty by default so the subchart auto-generates a random password and stores it in the `<release>-postgresql` secret; set explicitly, or use `postgresql.auth.existingSecret`, to pin it. | `""`                   |
 | `postgresql.image.tag`                                   | PostgreSQL Image tag                                                                                          | `13.8.0-debian-11-r18` |
 | `postgresql.primary.persistence.enabled`                 | Enable persistence using PVC                                                                                  | `false`                |
 | `postgresql.primary.persistence.storageClass`            | PVC Storage Class for PostgreSQL volume                                                                       | `nil`                  |

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -206,7 +206,13 @@ postgresql:
   auth:
     username: postgres
     database: nebraska
-    postgresPassword: changeIt
+    # Left empty on purpose: the bitnami postgresql subchart generates a
+    # random password on install and stores it in the
+    # `<release>-postgresql` secret when this is unset and
+    # existingSecret is not used. Do not hardcode a default here — a
+    # shipped default password is a working credential to every
+    # deployment that doesn't override it.
+    postgresPassword: ""
   image:
     registry: docker.io
     repository: bitnamilegacy/postgresql


### PR DESCRIPTION
## Summary

* `postgresql.auth.postgresPassword` was hardcoded to `changeIt`. Any install that didn't override it deployed with that literal, published string as the database administrator password — a working credential to every un-overridden deployment, sitting in a public repo.
* Default is now empty. The bitnami postgresql subchart treats an empty `postgresPassword` (with no `existingSecret` set) as a signal to generate a random password at install time and store it in the `<release>-postgresql` secret — exactly the secret the chart's own `passwordExistingSecret` field already reads from. No other changes needed.
* Existing installs that already set their own password are unaffected. Fresh installs get a unique generated credential instead of a public default.
* NOTES.txt now prints how to retrieve the generated password after install.
* README parameter table and CHANGELOG updated.

## Test plan

Verified on a local kind cluster (deleted after testing):

* `helm lint` clean
* Fresh install succeeds with no password override
* Random password generated and stored in `<release>-postgresql` secret
* App pod connects successfully with the generated password — no DB errors in logs
* Both pods reach `Running`