### PR TITLE
api: add opt-in instance retention pruner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 
+- **Optional instance retention:** Added `--instance-retention` (default off) to delete instances that have not checked in within a given duration, with dry-run, batched deletes, and `nebraska_instances_pruned_total`. See `docs/instance-retention.md`. ([#1603](https://github.com/flatcar/nebraska/pull/1603))
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.
 - **OEM Attribute Capture:** Instances now store OEM and Aleph version information from Omaha update requests. ([#1286](https://github.com/flatcar/nebraska/pull/1286))
 - **Multi-Step Updates with Floor Packages:** Added support for mandatory intermediate update versions (floor packages) that clients must install before reaching the target version. This enables safe migration paths for breaking changes by ensuring clients update through specific versions in order. Floor packages can be configured per channel with optional reasons and are architecture-specific. ([#1195](https://github.com/flatcar/nebraska/pull/1195))

--- a/backend/pkg/api/runtime/prune.go
+++ b/backend/pkg/api/runtime/prune.go
@@ -1,11 +1,16 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
 
-const defaultPruneBatchSize = 500
+const (
+	defaultPruneBatchSize  = 500
+	defaultPruneMaxBatches = 20
+	defaultPruneTimeout    = 2 * time.Minute
+)
 
 // PruneStaleInstancesResult is the outcome of one prune pass.
 type PruneStaleInstancesResult struct {
@@ -14,6 +19,9 @@ type PruneStaleInstancesResult struct {
 	Candidates int64
 	// Deleted is the number of instance rows actually removed. Zero in dry-run.
 	Deleted int64
+	// MoreRemain is true when this pass hit the per-run batch cap and stale
+	// rows are likely still present for a later tick.
+	MoreRemain bool
 }
 
 // PruneStaleInstances deletes (or counts, when dryRun is true) instances whose
@@ -21,16 +29,28 @@ type PruneStaleInstancesResult struct {
 // registered an application fall back to instance.created_ts.
 //
 // Related rows in instance_application, instance_status_history, event and
-// activity are removed by ON DELETE CASCADE. Work happens in batches so a
-// large fleet does not hold a long lock on instance.
+// activity are removed by ON DELETE CASCADE. Each DELETE is limited to
+// batchSize rows, and a single call processes at most a handful of batches so
+// a first enable against years of dead nodes cannot lock the hot tables for
+// the whole hour.
 func (s *Service) PruneStaleInstances(cutoff time.Time, batchSize int, dryRun bool) (PruneStaleInstancesResult, error) {
+	return s.pruneStaleInstances(cutoff, batchSize, defaultPruneMaxBatches, dryRun)
+}
+
+func (s *Service) pruneStaleInstances(cutoff time.Time, batchSize, maxBatches int, dryRun bool) (PruneStaleInstancesResult, error) {
 	if batchSize <= 0 {
 		batchSize = defaultPruneBatchSize
 	}
+	if maxBatches <= 0 {
+		maxBatches = defaultPruneMaxBatches
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultPruneTimeout)
+	defer cancel()
 
 	if dryRun {
 		var count int64
-		err := s.db.QueryRowx(`
+		err := s.db.QueryRowxContext(ctx, `
 			SELECT COUNT(*) FROM (
 				SELECT i.id
 				FROM instance i
@@ -46,30 +66,42 @@ func (s *Service) PruneStaleInstances(cutoff time.Time, batchSize int, dryRun bo
 	}
 
 	var deleted int64
-	for {
-		result, err := s.db.Exec(`
-			DELETE FROM instance
-			WHERE id IN (
+	var moreRemain bool
+	for batch := 0; batch < maxBatches; batch++ {
+		result, err := s.db.ExecContext(ctx, `
+			WITH stale AS (
 				SELECT i.id
 				FROM instance i
 				LEFT JOIN instance_application ia ON ia.instance_id = i.id
 				GROUP BY i.id, i.created_ts
 				HAVING COALESCE(MAX(ia.last_check_for_updates), i.created_ts) < $1
+				ORDER BY COALESCE(MAX(ia.last_check_for_updates), i.created_ts) ASC, i.id ASC
 				LIMIT $2
 			)
+			DELETE FROM instance i
+			USING stale
+			WHERE i.id = stale.id
+			  AND COALESCE(
+					(SELECT MAX(ia2.last_check_for_updates) FROM instance_application ia2 WHERE ia2.instance_id = i.id),
+					i.created_ts
+			  ) < $1
 		`, cutoff, batchSize)
 		if err != nil {
-			return PruneStaleInstancesResult{}, fmt.Errorf("delete stale instances: %w", err)
+			return PruneStaleInstancesResult{Candidates: deleted, Deleted: deleted}, fmt.Errorf("delete stale instances: %w", err)
 		}
 		n, err := result.RowsAffected()
 		if err != nil {
-			return PruneStaleInstancesResult{}, fmt.Errorf("stale instance rows affected: %w", err)
+			return PruneStaleInstancesResult{Candidates: deleted, Deleted: deleted}, fmt.Errorf("stale instance rows affected: %w", err)
 		}
 		deleted += n
 		if n < int64(batchSize) {
+			moreRemain = false
 			break
+		}
+		if batch == maxBatches-1 {
+			moreRemain = true
 		}
 	}
 
-	return PruneStaleInstancesResult{Candidates: deleted, Deleted: deleted}, nil
+	return PruneStaleInstancesResult{Candidates: deleted, Deleted: deleted, MoreRemain: moreRemain}, nil
 }

--- a/backend/pkg/api/runtime/prune.go
+++ b/backend/pkg/api/runtime/prune.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"fmt"
+	"time"
+)
+
+const defaultPruneBatchSize = 500
+
+// PruneStaleInstancesResult is the outcome of one prune pass.
+type PruneStaleInstancesResult struct {
+	// Candidates is the number of instances matching the cutoff. In a live
+	// run this equals Deleted; in a dry-run it is the would-delete count.
+	Candidates int64
+	// Deleted is the number of instance rows actually removed. Zero in dry-run.
+	Deleted int64
+}
+
+// PruneStaleInstances deletes (or counts, when dryRun is true) instances whose
+// newest last_check_for_updates is older than cutoff. Instances that never
+// registered an application fall back to instance.created_ts.
+//
+// Related rows in instance_application, instance_status_history, event and
+// activity are removed by ON DELETE CASCADE. Work happens in batches so a
+// large fleet does not hold a long lock on instance.
+func (s *Service) PruneStaleInstances(cutoff time.Time, batchSize int, dryRun bool) (PruneStaleInstancesResult, error) {
+	if batchSize <= 0 {
+		batchSize = defaultPruneBatchSize
+	}
+
+	if dryRun {
+		var count int64
+		err := s.db.QueryRowx(`
+			SELECT COUNT(*) FROM (
+				SELECT i.id
+				FROM instance i
+				LEFT JOIN instance_application ia ON ia.instance_id = i.id
+				GROUP BY i.id, i.created_ts
+				HAVING COALESCE(MAX(ia.last_check_for_updates), i.created_ts) < $1
+			) stale
+		`, cutoff).Scan(&count)
+		if err != nil {
+			return PruneStaleInstancesResult{}, fmt.Errorf("count stale instances: %w", err)
+		}
+		return PruneStaleInstancesResult{Candidates: count}, nil
+	}
+
+	var deleted int64
+	for {
+		result, err := s.db.Exec(`
+			DELETE FROM instance
+			WHERE id IN (
+				SELECT i.id
+				FROM instance i
+				LEFT JOIN instance_application ia ON ia.instance_id = i.id
+				GROUP BY i.id, i.created_ts
+				HAVING COALESCE(MAX(ia.last_check_for_updates), i.created_ts) < $1
+				LIMIT $2
+			)
+		`, cutoff, batchSize)
+		if err != nil {
+			return PruneStaleInstancesResult{}, fmt.Errorf("delete stale instances: %w", err)
+		}
+		n, err := result.RowsAffected()
+		if err != nil {
+			return PruneStaleInstancesResult{}, fmt.Errorf("stale instance rows affected: %w", err)
+		}
+		deleted += n
+		if n < int64(batchSize) {
+			break
+		}
+	}
+
+	return PruneStaleInstancesResult{Candidates: deleted, Deleted: deleted}, nil
+}

--- a/backend/pkg/api/runtime/prune_test.go
+++ b/backend/pkg/api/runtime/prune_test.go
@@ -7,29 +7,40 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 
+	"github.com/flatcar/nebraska/backend/pkg/api"
+	"github.com/flatcar/nebraska/backend/pkg/api/admin"
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
 	"github.com/flatcar/nebraska/backend/pkg/api/types"
 )
 
+func setupPruneGroup(t *testing.T, a *api.API, name string) (*admin.Service, *Service, *types.Application, *types.Group) {
+	t.Helper()
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+	tTeam, err := as.AddTeam(&types.Team{Name: name + "_team"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&types.Application{Name: name + "_app", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tGroup, err := as.AddGroup(&types.Group{Name: name + "_group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+	return as, rs, tApp, tGroup
+}
+
+func backdateCheckIn(t *testing.T, a *api.API, instanceID string, age time.Duration) {
+	t.Helper()
+	_, err := dbconn.DB(a.Conn()).Exec(
+		`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`,
+		time.Now().UTC().Add(-age),
+		instanceID,
+	)
+	require.NoError(t, err)
+}
+
 func TestPruneStaleInstancesDeletesOldAndKeepsFresh(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()
-	as := adminSvc(a)
-	rs := runtimeSvc(a)
-	db := dbconn.DB(a.Conn())
-
-	tTeam, err := as.AddTeam(&types.Team{Name: "prune_team"})
-	require.NoError(t, err)
-	tApp, err := as.AddApp(&types.Application{Name: "prune_app", TeamID: tTeam.ID})
-	require.NoError(t, err)
-	tPkg, err := as.AddPackage(&types.Package{Type: types.PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
-	require.NoError(t, err)
-	tChannel, err := as.AddChannel(&types.Channel{Name: "prune_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
-	require.NoError(t, err)
-	tGroup, err := as.AddGroup(&types.Group{Name: "prune_group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	require.NoError(t, err)
+	_, rs, tApp, tGroup := setupPruneGroup(t, a, "prune")
 
 	stale, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
 	require.NoError(t, err)
@@ -38,15 +49,12 @@ func TestPruneStaleInstancesDeletesOldAndKeepsFresh(t *testing.T) {
 
 	require.NoError(t, rs.grantUpdate(stale, "1.0.1"))
 	require.NoError(t, rs.updateInstanceStatus(stale.ID, tApp.ID, types.InstanceStatusComplete))
+	backdateCheckIn(t, a, stale.ID, 2*time.Hour)
 
-	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), stale.ID)
-	require.NoError(t, err)
-
-	cutoff := time.Now().UTC().Add(-time.Hour)
-	result, err := rs.PruneStaleInstances(cutoff, 500, false)
+	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), result.Deleted)
-	assert.Equal(t, int64(1), result.Candidates)
+	assert.False(t, result.MoreRemain)
 
 	_, err = a.GetInstance(stale.ID, tApp.ID)
 	assert.Error(t, err, "stale instance should be gone")
@@ -63,25 +71,15 @@ func TestPruneStaleInstancesDeletesOldAndKeepsFresh(t *testing.T) {
 func TestPruneStaleInstancesDryRunDoesNotDelete(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()
-	as := adminSvc(a)
-	rs := runtimeSvc(a)
-	db := dbconn.DB(a.Conn())
-
-	tTeam, err := as.AddTeam(&types.Team{Name: "prune_dry_team"})
-	require.NoError(t, err)
-	tApp, err := as.AddApp(&types.Application{Name: "prune_dry_app", TeamID: tTeam.ID})
-	require.NoError(t, err)
-	tGroup, err := as.AddGroup(&types.Group{Name: "prune_dry_group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	require.NoError(t, err)
+	_, rs, tApp, tGroup := setupPruneGroup(t, a, "prune_dry")
 
 	stale, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.3"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
 	require.NoError(t, err)
-	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), stale.ID)
-	require.NoError(t, err)
+	backdateCheckIn(t, a, stale.ID, 2*time.Hour)
 
 	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, true)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, result.Candidates, int64(1))
+	assert.Equal(t, int64(1), result.Candidates)
 	assert.Equal(t, int64(0), result.Deleted)
 
 	_, err = a.GetInstance(stale.ID, tApp.ID)
@@ -91,17 +89,8 @@ func TestPruneStaleInstancesDryRunDoesNotDelete(t *testing.T) {
 func TestPruneStaleInstancesKeepsInstanceWithAnyFreshCheckIn(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()
-	as := adminSvc(a)
-	rs := runtimeSvc(a)
-	db := dbconn.DB(a.Conn())
-
-	tTeam, err := as.AddTeam(&types.Team{Name: "prune_multi_team"})
-	require.NoError(t, err)
-	tApp1, err := as.AddApp(&types.Application{Name: "prune_multi_app1", TeamID: tTeam.ID})
-	require.NoError(t, err)
-	tApp2, err := as.AddApp(&types.Application{Name: "prune_multi_app2", TeamID: tTeam.ID})
-	require.NoError(t, err)
-	tGroup1, err := as.AddGroup(&types.Group{Name: "prune_multi_g1", ApplicationID: tApp1.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	as, rs, tApp1, tGroup1 := setupPruneGroup(t, a, "prune_multi")
+	tApp2, err := as.AddApp(&types.Application{Name: "prune_multi_app2", TeamID: tApp1.TeamID})
 	require.NoError(t, err)
 	tGroup2, err := as.AddGroup(&types.Group{Name: "prune_multi_g2", ApplicationID: tApp2.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	require.NoError(t, err)
@@ -112,7 +101,12 @@ func TestPruneStaleInstancesKeepsInstanceWithAnyFreshCheckIn(t *testing.T) {
 	_, err = rs.RegisterInstance(types.Instance{ID: id, IP: "10.0.0.4"}, NewInstanceApplication(tApp2.ID, tGroup2.ID, "1.0.0"))
 	require.NoError(t, err)
 
-	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2 AND application_id = $3`, time.Now().UTC().Add(-24*time.Hour), id, tApp1.ID)
+	_, err = dbconn.DB(a.Conn()).Exec(
+		`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2 AND application_id = $3`,
+		time.Now().UTC().Add(-24*time.Hour),
+		id,
+		tApp1.ID,
+	)
 	require.NoError(t, err)
 
 	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, false)
@@ -126,34 +120,51 @@ func TestPruneStaleInstancesKeepsInstanceWithAnyFreshCheckIn(t *testing.T) {
 func TestPruneStaleInstancesBatches(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()
-	as := adminSvc(a)
-	rs := runtimeSvc(a)
-	db := dbconn.DB(a.Conn())
-
-	tTeam, err := as.AddTeam(&types.Team{Name: "prune_batch_team"})
-	require.NoError(t, err)
-	tApp, err := as.AddApp(&types.Application{Name: "prune_batch_app", TeamID: tTeam.ID})
-	require.NoError(t, err)
-	tGroup, err := as.AddGroup(&types.Group{Name: "prune_batch_group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	require.NoError(t, err)
+	_, rs, tApp, tGroup := setupPruneGroup(t, a, "prune_batch")
 
 	ids := make([]string, 3)
 	for i := range ids {
 		inst, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.10"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
 		require.NoError(t, err)
 		ids[i] = inst.ID
-		_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), inst.ID)
-		require.NoError(t, err)
+		backdateCheckIn(t, a, inst.ID, 2*time.Hour)
 	}
 
 	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 2, false)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, result.Deleted, int64(3))
+	assert.Equal(t, int64(3), result.Deleted)
 
 	for _, id := range ids {
 		_, err := a.GetInstance(id, tApp.ID)
 		assert.Error(t, err, "batched prune should remove all stale instances")
 	}
+}
+
+func TestPruneStaleInstancesRespectsMaxBatches(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	_, rs, tApp, tGroup := setupPruneGroup(t, a, "prune_cap")
+
+	ids := make([]string, 3)
+	for i := range ids {
+		inst, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.11"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+		require.NoError(t, err)
+		ids[i] = inst.ID
+		backdateCheckIn(t, a, inst.ID, 2*time.Hour)
+	}
+
+	result, err := rs.pruneStaleInstances(time.Now().UTC().Add(-time.Hour), 1, 2, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.Deleted)
+	assert.True(t, result.MoreRemain)
+
+	remaining := 0
+	for _, id := range ids {
+		if _, err := a.GetInstance(id, tApp.ID); err == nil {
+			remaining++
+		}
+	}
+	assert.Equal(t, 1, remaining)
 }
 
 func TestPruneStaleInstancesOrphanCreatedTs(t *testing.T) {
@@ -168,7 +179,7 @@ func TestPruneStaleInstancesOrphanCreatedTs(t *testing.T) {
 
 	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, false)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, result.Deleted, int64(1))
+	assert.Equal(t, int64(1), result.Deleted)
 
 	var n int
 	err = db.QueryRowx(`SELECT COUNT(*) FROM instance WHERE id = $1`, orphanID).Scan(&n)

--- a/backend/pkg/api/runtime/prune_test.go
+++ b/backend/pkg/api/runtime/prune_test.go
@@ -1,0 +1,177 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
+	"github.com/flatcar/nebraska/backend/pkg/api/types"
+)
+
+func TestPruneStaleInstancesDeletesOldAndKeepsFresh(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+	db := dbconn.DB(a.Conn())
+
+	tTeam, err := as.AddTeam(&types.Team{Name: "prune_team"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&types.Application{Name: "prune_app", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tPkg, err := as.AddPackage(&types.Package{Type: types.PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	require.NoError(t, err)
+	tChannel, err := as.AddChannel(&types.Channel{Name: "prune_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	require.NoError(t, err)
+	tGroup, err := as.AddGroup(&types.Group{Name: "prune_group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+
+	stale, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+	require.NoError(t, err)
+	fresh, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.2"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+	require.NoError(t, err)
+
+	require.NoError(t, rs.grantUpdate(stale, "1.0.1"))
+	require.NoError(t, rs.updateInstanceStatus(stale.ID, tApp.ID, types.InstanceStatusComplete))
+
+	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), stale.ID)
+	require.NoError(t, err)
+
+	cutoff := time.Now().UTC().Add(-time.Hour)
+	result, err := rs.PruneStaleInstances(cutoff, 500, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.Deleted)
+	assert.Equal(t, int64(1), result.Candidates)
+
+	_, err = a.GetInstance(stale.ID, tApp.ID)
+	assert.Error(t, err, "stale instance should be gone")
+
+	stillThere, err := a.GetInstance(fresh.ID, tApp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, fresh.ID, stillThere.ID)
+
+	history, err := a.GetInstanceStatusHistory(stale.ID, tApp.ID, tGroup.ID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, history, "status history should cascade-delete with the instance")
+}
+
+func TestPruneStaleInstancesDryRunDoesNotDelete(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+	db := dbconn.DB(a.Conn())
+
+	tTeam, err := as.AddTeam(&types.Team{Name: "prune_dry_team"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&types.Application{Name: "prune_dry_app", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tGroup, err := as.AddGroup(&types.Group{Name: "prune_dry_group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+
+	stale, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.3"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+	require.NoError(t, err)
+	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), stale.ID)
+	require.NoError(t, err)
+
+	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, true)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Candidates, int64(1))
+	assert.Equal(t, int64(0), result.Deleted)
+
+	_, err = a.GetInstance(stale.ID, tApp.ID)
+	require.NoError(t, err, "dry-run must not delete the instance")
+}
+
+func TestPruneStaleInstancesKeepsInstanceWithAnyFreshCheckIn(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+	db := dbconn.DB(a.Conn())
+
+	tTeam, err := as.AddTeam(&types.Team{Name: "prune_multi_team"})
+	require.NoError(t, err)
+	tApp1, err := as.AddApp(&types.Application{Name: "prune_multi_app1", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tApp2, err := as.AddApp(&types.Application{Name: "prune_multi_app2", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tGroup1, err := as.AddGroup(&types.Group{Name: "prune_multi_g1", ApplicationID: tApp1.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+	tGroup2, err := as.AddGroup(&types.Group{Name: "prune_multi_g2", ApplicationID: tApp2.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+	_, err = rs.RegisterInstance(types.Instance{ID: id, IP: "10.0.0.4"}, NewInstanceApplication(tApp1.ID, tGroup1.ID, "1.0.0"))
+	require.NoError(t, err)
+	_, err = rs.RegisterInstance(types.Instance{ID: id, IP: "10.0.0.4"}, NewInstanceApplication(tApp2.ID, tGroup2.ID, "1.0.0"))
+	require.NoError(t, err)
+
+	_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2 AND application_id = $3`, time.Now().UTC().Add(-24*time.Hour), id, tApp1.ID)
+	require.NoError(t, err)
+
+	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, false)
+	require.NoError(t, err)
+
+	_, err = a.GetInstance(id, tApp2.ID)
+	require.NoError(t, err, "instance must stay if any application still checks in")
+	assert.Equal(t, int64(0), result.Deleted)
+}
+
+func TestPruneStaleInstancesBatches(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+	rs := runtimeSvc(a)
+	db := dbconn.DB(a.Conn())
+
+	tTeam, err := as.AddTeam(&types.Team{Name: "prune_batch_team"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&types.Application{Name: "prune_batch_app", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tGroup, err := as.AddGroup(&types.Group{Name: "prune_batch_group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+
+	ids := make([]string, 3)
+	for i := range ids {
+		inst, err := rs.RegisterInstance(types.Instance{ID: uuid.New().String(), IP: "10.0.0.10"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+		require.NoError(t, err)
+		ids[i] = inst.ID
+		_, err = db.Exec(`UPDATE instance_application SET last_check_for_updates = $1 WHERE instance_id = $2`, time.Now().UTC().Add(-2*time.Hour), inst.ID)
+		require.NoError(t, err)
+	}
+
+	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 2, false)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Deleted, int64(3))
+
+	for _, id := range ids {
+		_, err := a.GetInstance(id, tApp.ID)
+		assert.Error(t, err, "batched prune should remove all stale instances")
+	}
+}
+
+func TestPruneStaleInstancesOrphanCreatedTs(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	rs := runtimeSvc(a)
+	db := dbconn.DB(a.Conn())
+
+	orphanID := uuid.New().String()
+	_, err := db.Exec(`INSERT INTO instance (id, ip, created_ts) VALUES ($1, $2, $3)`, orphanID, "10.0.0.9", time.Now().UTC().Add(-3*time.Hour))
+	require.NoError(t, err)
+
+	result, err := rs.PruneStaleInstances(time.Now().UTC().Add(-time.Hour), 500, false)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Deleted, int64(1))
+
+	var n int
+	err = db.QueryRowx(`SELECT COUNT(*) FROM instance WHERE id = $1`, orphanID).Scan(&n)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/providers/basicflag"
@@ -54,6 +55,14 @@ type Config struct {
 	OidcUseUserInfo   bool   `koanf:"oidc-use-userinfo"`
 	CAFile            string `koanf:"ca-file"`
 	CACertPool        *x509.CertPool
+
+	// InstanceRetention, when greater than zero, enables a background job that
+	// deletes instances whose newest last_check_for_updates (or created_ts if
+	// they never checked in) is older than this duration. Zero disables it so
+	// existing deployments do not change behaviour on upgrade.
+	InstanceRetention          time.Duration `koanf:"instance-retention"`
+	InstanceRetentionDryRun    bool          `koanf:"instance-retention-dry-run"`
+	InstanceRetentionBatchSize uint          `koanf:"instance-retention-batch-size"`
 }
 
 const (
@@ -98,6 +107,13 @@ func (c *Config) Validate() error {
 		if _, err := os.Stat(c.CAFile); err != nil {
 			return fmt.Errorf("invalid ca-file: %w", err)
 		}
+	}
+
+	if c.InstanceRetention < 0 {
+		return errors.New("instance-retention must be zero or a positive duration")
+	}
+	if c.InstanceRetention > 0 && c.InstanceRetentionBatchSize == 0 {
+		return errors.New("instance-retention-batch-size must be greater than zero when instance-retention is enabled")
 	}
 
 	return nil
@@ -145,6 +161,9 @@ func Parse() (*Config, error) {
 	f.String("api-endpoint-suffix", "", "Additional suffix for the API endpoint to serve Omaha clients on; use a secret to only serve your clients, e.g., mysecret results in /v1/update/mysecret")
 	f.Bool("debug", false, "sets log level to debug")
 	f.Uint("port", 8000, "port to run server")
+	f.Duration("instance-retention", 0, "delete instances whose newest last_check_for_updates (or created_ts if they never checked in) is older than this duration; 0 disables the pruner")
+	f.Bool("instance-retention-dry-run", false, "log how many instances would be deleted by instance-retention without deleting them")
+	f.Uint("instance-retention-batch-size", 500, "maximum number of instances deleted per batch when instance-retention is enabled")
 
 	k := koanf.New(".")
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -115,6 +115,9 @@ func (c *Config) Validate() error {
 	if c.InstanceRetention > 0 && c.InstanceRetentionBatchSize == 0 {
 		return errors.New("instance-retention-batch-size must be greater than zero when instance-retention is enabled")
 	}
+	if c.InstanceRetentionBatchSize > 10000 {
+		return errors.New("instance-retention-batch-size must be at most 10000")
+	}
 
 	return nil
 }

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateInstanceRetention(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		c := &Config{AuthMode: "noop"}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("enabled requires batch size", func(t *testing.T) {
+		c := &Config{AuthMode: "noop", InstanceRetention: time.Hour}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("enabled with batch size", func(t *testing.T) {
+		c := &Config{AuthMode: "noop", InstanceRetention: time.Hour, InstanceRetentionBatchSize: 500}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("negative retention", func(t *testing.T) {
+		c := &Config{AuthMode: "noop", InstanceRetention: -time.Hour, InstanceRetentionBatchSize: 500}
+		assert.Error(t, c.Validate())
+	})
+}

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -27,4 +27,9 @@ func TestValidateInstanceRetention(t *testing.T) {
 		c := &Config{AuthMode: "noop", InstanceRetention: -time.Hour, InstanceRetentionBatchSize: 500}
 		assert.Error(t, c.Validate())
 	})
+
+	t.Run("batch size too large", func(t *testing.T) {
+		c := &Config{AuthMode: "noop", InstanceRetention: time.Hour, InstanceRetentionBatchSize: 10001}
+		assert.Error(t, c.Validate())
+	})
 }

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -64,8 +64,24 @@ var (
 		},
 	)
 
+	instancesPrunedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "nebraska",
+			Name:      "instances_pruned_total",
+			Help:      "Number of stale instances deleted by the instance-retention pruner",
+		},
+	)
+
 	l = logger.New("nebraska")
 )
+
+// AddInstancesPruned increments the instances_pruned_total counter.
+func AddInstancesPruned(n float64) {
+	if n <= 0 {
+		return
+	}
+	instancesPrunedTotal.Add(n)
+}
 
 // registerNebraskaMetrics registers the application metrics collector with the DefaultRegistrer.
 func registerNebraskaMetrics() error {
@@ -75,6 +91,7 @@ func registerNebraskaMetrics() error {
 		openConnections,
 		inUseConnections,
 		idleConnections,
+		instancesPrunedTotal,
 	}
 
 	for _, collector := range collectors {

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/config"
 	"github.com/flatcar/nebraska/backend/pkg/handler"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
+	"github.com/flatcar/nebraska/backend/pkg/metrics"
 	custommiddleware "github.com/flatcar/nebraska/backend/pkg/middleware"
 	"github.com/flatcar/nebraska/backend/pkg/sessions"
 	echosessions "github.com/flatcar/nebraska/backend/pkg/sessions/echo"
@@ -149,25 +150,52 @@ func New(conf *config.Config, db *db.API, adminSvc *admin.Service, runtimeSvc *r
 		e.DefaultHTTPErrorHandler(err, c)
 	}
 
-	// setup background job for updating instance stats
+	// setup background job for updating instance stats and optional instance retention
 	go func() {
-		// update once at startup
-		err = runtimeSvc.UpdateInstanceStats(nil, nil)
-		if err != nil {
-			l.Err(err).Msg("Error updating instance stats")
-		}
+		runInstanceStatsAndPrune(conf, runtimeSvc)
 		ticker := time.NewTicker(time.Hour)
 		defer ticker.Stop()
 
 		for range ticker.C {
-			err := runtimeSvc.UpdateInstanceStats(nil, nil)
-			if err != nil {
-				l.Err(err).Msg("Error updating instance stats")
-			}
+			runInstanceStatsAndPrune(conf, runtimeSvc)
 		}
 	}()
 
 	return e, nil
+}
+
+func runInstanceStatsAndPrune(conf *config.Config, runtimeSvc *runtime.Service) {
+	err := runtimeSvc.UpdateInstanceStats(nil, nil)
+	if err != nil {
+		l.Err(err).Msg("Error updating instance stats")
+	}
+
+	if conf.InstanceRetention <= 0 {
+		return
+	}
+
+	cutoff := time.Now().UTC().Add(-conf.InstanceRetention)
+	result, err := runtimeSvc.PruneStaleInstances(cutoff, int(conf.InstanceRetentionBatchSize), conf.InstanceRetentionDryRun)
+	if err != nil {
+		l.Err(err).Dur("retention", conf.InstanceRetention).Msg("Error pruning stale instances")
+		return
+	}
+
+	if conf.InstanceRetentionDryRun {
+		l.Info().
+			Int64("candidates", result.Candidates).
+			Dur("retention", conf.InstanceRetention).
+			Msg("instance retention dry-run; no rows deleted")
+		return
+	}
+
+	if result.Deleted > 0 {
+		metrics.AddInstancesPruned(float64(result.Deleted))
+	}
+	l.Info().
+		Int64("deleted", result.Deleted).
+		Dur("retention", conf.InstanceRetention).
+		Msg("instance retention pruned stale instances")
 }
 
 func setupAuthenticator(conf config.Config, sessionStore *sessions.Store, defaultTeamID string) (auth.Authenticator, error) {

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -189,11 +189,16 @@ func runInstanceStatsAndPrune(conf *config.Config, runtimeSvc *runtime.Service) 
 		return
 	}
 
+	if result.Deleted == 0 && !result.MoreRemain {
+		return
+	}
+
 	if result.Deleted > 0 {
 		metrics.AddInstancesPruned(float64(result.Deleted))
 	}
 	l.Info().
 		Int64("deleted", result.Deleted).
+		Bool("more_remain", result.MoreRemain).
 		Dur("retention", conf.InstanceRetention).
 		Msg("instance retention pruned stale instances")
 }

--- a/docs/instance-retention.md
+++ b/docs/instance-retention.md
@@ -48,8 +48,10 @@ The job runs once at startup and then every hour, next to the existing
 
 ## What is deleted
 
-Each pass deletes up to `instance-retention-batch-size` rows from `instance`
-(`500` by default) and repeats until none remain. Foreign keys on related
+Each hourly pass deletes up to `instance-retention-batch-size` rows per
+statement (`500` by default) and at most 20 statements, so a first enable
+against a large backlog cannot lock the hot tables for the whole hour.
+Remaining stale rows are picked up on later ticks. Foreign keys on related
 tables are `ON DELETE CASCADE`, so history, events, and activity for those
 machines go with them.
 

--- a/docs/instance-retention.md
+++ b/docs/instance-retention.md
@@ -1,0 +1,62 @@
+# Instance retention
+
+Nebraska records every machine that checks in. Those rows are never removed
+unless you enable this optional pruner.
+
+Kubernetes clusters that replace Flatcar nodes often leave years of dead
+`instance` rows behind, along with `instance_application`,
+`instance_status_history`, `event`, and `activity` rows. That growth is what
+makes reporting queries and indexes more expensive over time.
+
+Retention is **off by default**. Existing deployments do not change behaviour
+on upgrade.
+
+## Enable it
+
+Pick instances by their newest `instance_application.last_check_for_updates`.
+If a machine never registered an application, `instance.created_ts` is used
+instead. An instance that still checks in for any application is kept.
+
+```text
+nebraska \
+  -auth-mode noop \
+  -instance-retention=2160h \
+  -instance-retention-batch-size=500
+```
+
+`2160h` is 90 days. Use whatever window matches how long a decommissioned
+node should stay visible.
+
+Helm users can pass the same flags through `extraArgs`.
+
+## Dry-run first
+
+Log the would-delete count without removing anything:
+
+```text
+nebraska \
+  -auth-mode noop \
+  -instance-retention=2160h \
+  -instance-retention-dry-run
+```
+
+Watch the log line `instance retention dry-run; no rows deleted` and the
+`candidates` field. Turn dry-run off only after that number looks right.
+
+The job runs once at startup and then every hour, next to the existing
+`instance_stats` updater.
+
+## What is deleted
+
+Each pass deletes up to `instance-retention-batch-size` rows from `instance`
+(`500` by default) and repeats until none remain. Foreign keys on related
+tables are `ON DELETE CASCADE`, so history, events, and activity for those
+machines go with them.
+
+`instance_stats` is an hourly aggregate table, not per-instance, and is not
+pruned by this job.
+
+## Metric
+
+`nebraska_instances_pruned_total` counts rows actually deleted. Dry-run does
+not increment it.


### PR DESCRIPTION
## Summary
- Adds an **opt-in** background job that deletes instances whose newest `last_check_for_updates` (or `created_ts` if they never checked in) is older than `-instance-retention`. Default remains `0` (disabled), so existing deployments do not change on upgrade.
- Dry-run (`-instance-retention-dry-run`) logs the would-delete count without removing rows. Live deletes run in batches; related `instance_application`, `instance_status_history`, `event`, and `activity` rows go with `ON DELETE CASCADE`.
- Increments `nebraska_instances_pruned_total` for actual deletes. Operator notes are in `docs/instance-retention.md`.

Fixes #1585. Operators with node churn described the same gap in #352.

## How to use
Retention stays off unless an operator sets a duration:

```
nebraska -instance-retention=2160h -instance-retention-dry-run
```

`2160h` is 90 days. Dry-run only logs `candidates`. Remove `-instance-retention-dry-run` to delete. Helm can pass the same flags via `extraArgs`.

## Testing done
Against Postgres 17:

```
go test ./pkg/config ./pkg/api/runtime -run 'TestValidateInstanceRetention|TestPruneStaleInstances'
```

Those tests passed: stale vs fresh, dry-run, multi-app keep, batched deletes, cascade of status history, orphan `created_ts` prune, and config validation.