### PR TITLE
chore(ci): ignore kubernetes slack link

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,3 +9,8 @@ https://x.com/flatcar
 
 # www.robotstxt.org times out frequently in CI
 https://www.robotstxt.org/robotstxt.html
+
+# kubernetes.slack.com rejects non-browser user agents such as lychee's with a
+# "browser not supported" 403. Checking it would be pointless anyway, since the
+# channel URL resolves to the workspace sign-in page rather than the channel.
+https://kubernetes.slack.com


### PR DESCRIPTION
The link checker fails on every PR:
[403] https://kubernetes.slack.com/archives/C03GQ8B5XNJ | Rejected status code: 403 Forbidden

Slack started returning `403` to non-browser user agents. The link itself is fine it works in a browser and is used unchanged across ~30 flatcar repos. Setting a browser UA would only get us a `200` on the sign-in page, not the channel, so there's nothing real to verify either way.