### PR TITLE
feat(db): allow a provider to supply the database password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 
+- **Pluggable database password provider:** The database password can now be supplied by Go code through the `api.DBPasswordProvider` interface instead of being carried in `NEBRASKA_DB_URL`. It is consulted before every physical connection, so credentials that expire, such as cloud IAM tokens, are picked up without a restart.
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.
 - **OEM Attribute Capture:** Instances now store OEM and Aleph version information from Omaha update requests. ([#1286](https://github.com/flatcar/nebraska/pull/1286))
 - **Multi-Step Updates with Floor Packages:** Added support for mandatory intermediate update versions (floor packages) that clients must install before reaching the target version. This enables safe migration paths for breaking changes by ensuring clients update through specific versions in order. Floor packages can be configured per channel with optional reasons and are architecture-specific. ([#1195](https://github.com/flatcar/nebraska/pull/1195))

--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -68,7 +68,7 @@ func (api *API) withMigrationsDB(fn func(*sqlx.DB) error) error {
 	conn, err := dbconn.Open(api.dbDriver, api.migrationsDBURL, dbconn.PoolConfig{
 		MaxOpenConns: 1,
 		MaxIdleConns: 1,
-	})
+	}, dbPasswordFunc())
 	if err != nil {
 		return fmt.Errorf("opening the migrations database connection: %w", err)
 	}
@@ -121,7 +121,7 @@ func New(options ...func(*API) error) (*API, error) {
 		MaxOpenConns:    maxOpenConns,
 		MaxIdleConns:    maxIdleConns,
 		ConnMaxLifetime: time.Duration(connMaxLifetime) * time.Second,
-	})
+	}, dbPasswordFunc())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/api/dbpassword.go
+++ b/backend/pkg/api/dbpassword.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"sync"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
+)
+
+// DBPasswordProvider supplies the password used to authenticate a database
+// connection. Nebraska calls it before opening every physical connection, so an
+// implementation is free to return a credential that expires, such as an OAuth
+// token, without Nebraska having to know how it is obtained.
+//
+// The user the connection is being made as is passed so that a single provider
+// can serve connections that authenticate as different roles.
+//
+// If connect_timeout is set in NEBRASKA_DB_URL, the context carries it as its
+// deadline, and an implementation is expected to honour it.
+type DBPasswordProvider interface {
+	DBPassword(ctx context.Context, user string) (string, error)
+}
+
+var (
+	dbPasswordMu       sync.RWMutex
+	dbPasswordProvider DBPasswordProvider
+)
+
+// SetDBPasswordProvider installs the provider New authenticates with. Call it
+// before New.
+func SetDBPasswordProvider(provider DBPasswordProvider) {
+	dbPasswordMu.Lock()
+	defer dbPasswordMu.Unlock()
+
+	dbPasswordProvider = provider
+}
+
+// dbPasswordFunc adapts the installed provider to what dbconn expects, and
+// returns nil when there is none.
+func dbPasswordFunc() dbconn.PasswordFunc {
+	dbPasswordMu.RLock()
+	defer dbPasswordMu.RUnlock()
+
+	if dbPasswordProvider == nil {
+		return nil
+	}
+
+	return dbPasswordProvider.DBPassword
+}

--- a/backend/pkg/api/dbpassword_test.go
+++ b/backend/pkg/api/dbpassword_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// rotatingPassword answers with a credential that changes between connections,
+// which is what an expiring token looks like from Nebraska's side.
+type rotatingPassword struct {
+	mu       sync.Mutex
+	password string
+	err      error
+	calls    int
+	users    []string
+}
+
+func (r *rotatingPassword) DBPassword(_ context.Context, user string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls++
+	r.users = append(r.users, user)
+
+	return r.password, r.err
+}
+
+func (r *rotatingPassword) set(password string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.password = password
+}
+
+func (r *rotatingPassword) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.calls
+}
+
+func (r *rotatingPassword) seenUsers() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]string(nil), r.users...)
+}
+
+// loginURLFor creates a login role and returns a copy of the test connection URL
+// that authenticates as it. The password in the URL is deliberately wrong, so a
+// connection only succeeds if the provider was consulted.
+func loginURLFor(t *testing.T, a *API, role, password string) string {
+	t.Helper()
+
+	_, err := a.db().Exec(fmt.Sprintf("drop role if exists %s", role))
+	require.NoError(t, err)
+
+	_, err = a.db().Exec(fmt.Sprintf("create role %s login password '%s'", role, password))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = a.db().Exec(fmt.Sprintf("drop role if exists %s", role))
+	})
+
+	parsed, err := url.Parse(os.Getenv("NEBRASKA_DB_URL"))
+	require.NoError(t, err)
+
+	parsed.User = url.UserPassword(role, "not-the-password")
+
+	return parsed.String()
+}
+
+func selectOne(a *API) error {
+	var one int
+
+	return a.db().QueryRow("select 1").Scan(&one)
+}
+
+func TestDBPasswordProviderIsUsedForEveryConnection(t *testing.T) {
+	admin, err := New()
+	require.NoError(t, err)
+	t.Cleanup(func() { admin.Close() })
+
+	const role = "nebraska_password_provider_test"
+
+	dbURL := loginURLFor(t, admin, role, "first")
+
+	provider := &rotatingPassword{password: "first"}
+	SetDBPasswordProvider(provider)
+	t.Cleanup(func() { SetDBPasswordProvider(nil) })
+
+	t.Setenv("NEBRASKA_DB_URL", dbURL)
+	// Without idle connections every query below needs a fresh physical one.
+	t.Setenv("NEBRASKA_DB_MAX_IDLE_CONNS", "0")
+
+	serving, err := New()
+	require.NoError(t, err)
+
+	defer serving.Close()
+
+	require.NoError(t, selectOne(serving))
+
+	_, err = admin.db().Exec(fmt.Sprintf("alter role %s password 'second'", role))
+	require.NoError(t, err)
+	provider.set("second")
+
+	require.NoError(t, selectOne(serving), "a rotated credential should be picked up by later connections")
+
+	require.Greater(t, provider.callCount(), 1)
+	for _, user := range provider.seenUsers() {
+		require.Equal(t, role, user)
+	}
+}
+
+func TestDBPasswordProviderErrorFailsTheConnection(t *testing.T) {
+	SetDBPasswordProvider(&rotatingPassword{err: errors.New("credential unavailable")})
+	t.Cleanup(func() { SetDBPasswordProvider(nil) })
+
+	_, err := New()
+	require.ErrorContains(t, err, "credential unavailable")
+}
+
+func TestWithoutDBPasswordProviderTheURLPasswordIsUsed(t *testing.T) {
+	require.Nil(t, dbPasswordFunc())
+
+	a, err := New()
+	require.NoError(t, err)
+
+	defer a.Close()
+
+	require.NoError(t, selectOne(a))
+}

--- a/backend/pkg/api/internal/dbconn/conn.go
+++ b/backend/pkg/api/internal/dbconn/conn.go
@@ -2,10 +2,18 @@
 package dbconn
 
 import (
+	"context"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 )
+
+// PasswordFunc returns the password for a connection authenticating as user. It
+// runs before every physical connection, so the password it returns is allowed
+// to expire.
+type PasswordFunc func(ctx context.Context, user string) (string, error)
 
 // PoolConfig holds the connection pool limits applied when the connection is opened.
 type PoolConfig struct {
@@ -20,9 +28,10 @@ type Conn struct {
 }
 
 // Open opens the database connection, verifies it is reachable and applies the
-// pool limits.
-func Open(driver string, url string, pool PoolConfig) (*Conn, error) {
-	db, err := sqlx.Open(driver, url)
+// pool limits. When password is non-nil it supplies the credential for every
+// physical connection, in place of the one carried in url.
+func Open(driver string, url string, pool PoolConfig, password PasswordFunc) (*Conn, error) {
+	db, err := open(driver, url, password)
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +44,42 @@ func Open(driver string, url string, pool PoolConfig) (*Conn, error) {
 	db.SetConnMaxLifetime(pool.ConnMaxLifetime)
 
 	return &Conn{db: db}, nil
+}
+
+// open builds the handle. The plain path leaves the URL to pgx, which re-reads
+// it for each connection; the provider path asks for the credential instead.
+func open(driver string, url string, password PasswordFunc) (*sqlx.DB, error) {
+	if password == nil {
+		return sqlx.Open(driver, url)
+	}
+
+	config, err := pgx.ParseConfig(url)
+	if err != nil {
+		return nil, err
+	}
+
+	db := stdlib.OpenDB(*config, stdlib.OptionBeforeConnect(func(ctx context.Context, connConfig *pgx.ConnConfig) error {
+		// pgx starts connect_timeout after this callback returns, so without this
+		// the credential call is the one step of opening a connection that nothing
+		// bounds.
+		if connConfig.ConnectTimeout > 0 {
+			var cancel context.CancelFunc
+
+			ctx, cancel = context.WithTimeout(ctx, connConfig.ConnectTimeout)
+			defer cancel()
+		}
+
+		value, err := password(ctx, connConfig.User)
+		if err != nil {
+			return err
+		}
+
+		connConfig.Password = value
+
+		return nil
+	}))
+
+	return sqlx.NewDb(db, driver), nil
 }
 
 // Close releases the connection.


### PR DESCRIPTION
# feat(db): allow a provider to supply the database password

Nebraska takes the database password from `NEBRASKA_DB_URL`. That string is fixed for the life of the process, so a deployment whose credential expires, such as an OAuth token from a cloud identity provider, has no in-process way to supply a new one: the first connection attempted after expiry fails, and so does every one after that.

`DBPasswordProvider` is an optional hook consulted before each physical connection. When one is installed the handle is opened through pgx's `BeforeConnect` callback, which runs for every new connection and receives a fresh copy of the connection config, so the provider can return a credential renewed since startup. How that credential is obtained is not Nebraska's concern, and no cloud SDK is added; `go.mod` is unchanged.

The callback runs before pgx applies `connect_timeout`, so the provider call is bounded by that same timeout. A provider that never answers fails the connection instead of holding up every one the pool is trying to open.

The provider is given the user the connection authenticates as, so a single provider can serve connections made as different roles. That is what a deployment needs if it ever runs migrations under a separate role, as #1575 proposes.

Deployments that install no provider are untouched. The plain `sqlx.Open` path runs exactly as before and the password keeps coming from `NEBRASKA_DB_URL`.

## How to use

No new behavior is introduced for anyone who does not install a provider, so the first thing to validate is that an existing deployment is not impacted at all.

To use it, implement the interface and install it in `cmd/nebraska/main.go` before the database is created:

```go
type tokenProvider struct{}

func (tokenProvider) DBPassword(ctx context.Context, user string) (string, error) {
    // fetch a short-lived credential for this role, e.g. a cloud IAM token
    return fetchToken(ctx, user)
}
```

```diff
 func main() {
     conf, err := config.Parse()
     ...
+	db.SetDBPasswordProvider(tokenProvider{})
+
     if conf.RollbackDBTo != "" {
         db, err := db.New()
```

It goes above the `RollbackDBTo` branch so it covers both connections `main` can open, the down-migration one and `db.NewWithMigrations()`.

The password in `NEBRASKA_DB_URL` is then ignored; the user, host and database in it are still used.

The same shape is used by [netdata](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/collector/postgres/collect.go) for Azure Entra ID and [bytebase](https://github.com/bytebase/bytebase/blob/main/backend/store/dbauth/aws.go) for AWS RDS IAM.


## Testing done

```console
$ cd backend
$ make code-checks
go build ./...
./tools/check_pkg_test.sh
NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
./tools/golangci-lint run --fix
0 issues.
go mod tidy
```

```console
$ make check-backend-with-container
ok  github.com/flatcar/nebraska/backend/pkg/api             22.504s
ok  github.com/flatcar/nebraska/backend/pkg/api/admin        0.248s
ok  github.com/flatcar/nebraska/backend/pkg/api/runtime      2.681s
ok  github.com/flatcar/nebraska/backend/pkg/auth             0.009s
ok  github.com/flatcar/nebraska/backend/pkg/middleware       0.008s
ok  github.com/flatcar/nebraska/backend/pkg/omaha            3.947s
ok  github.com/flatcar/nebraska/backend/pkg/random           0.003s
ok  github.com/flatcar/nebraska/backend/pkg/sessions         0.006s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache      0.005s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache/gob  0.005s
ok  github.com/flatcar/nebraska/backend/pkg/syncer           5.749s
ok  github.com/flatcar/nebraska/backend/test/api            21.491s
ok  github.com/flatcar/nebraska/backend/test/auth/oidc       3.772s
```

Three tests cover the new path: that the provider is consulted for every connection and a rotated credential is picked up, that a provider error fails the connection, and that without a provider the URL password is still used.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.