### PR TITLE
fix(api): bound update-history cache with a size-limited LRU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+
+- **Bounded the group version count timeline cache:** the cache backing the group update-history charts was a plain map keyed by group ID and duration. Stale entries were recomputed but never removed, so every distinct group ID a caller supplied added a permanent entry and memory grew for the lifetime of the process. It is now a size-bounded LRU cache, which keeps memory flat when a caller iterates over arbitrary group IDs.
+
 ### Added
 
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/jmoiron/sqlx v1.4.0
@@ -137,7 +138,6 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/backend/pkg/api/internal/dbreads/groups.go
+++ b/backend/pkg/api/internal/dbreads/groups.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/types"
@@ -51,12 +52,32 @@ var (
 	// itself. An alternative is to use atomic loads instead of RLock()
 	// and using atomic stores inside Lock() of a normal Mutex to serialize
 	// the writes (or use channel handshakes instead of a mutex).
-	cachedGroups                    map[types.GroupDescriptor]string
-	cachedGroupsLock                sync.RWMutex
-	cachedGroupVersionCount         = make(map[groupDurationCacheKey]groupVersionCountCache)
-	cachedGroupVersionCountLock     sync.RWMutex
+	cachedGroups     map[types.GroupDescriptor]string
+	cachedGroupsLock sync.RWMutex
+	// cachedGroupVersionCount caches version count timelines keyed by group
+	// and duration. It is size-bounded and evicts the least recently used
+	// entry once full: entries are only ever refreshed, never deleted, so an
+	// unbounded map would grow for the lifetime of the process for every
+	// distinct group ID a caller supplies.
+	cachedGroupVersionCount         = newGroupVersionCountCache()
 	CachedGroupVersionCountLifespan = time.Minute
 )
+
+// maxCachedGroupVersionCountEntries bounds the number of entries kept in
+// cachedGroupVersionCount. The key space is (group, duration) and there are
+// four valid durations, so this holds the timelines of a few hundred groups —
+// far more than a deployment serves in practice, while keeping memory flat
+// when a caller iterates over arbitrary group IDs.
+const maxCachedGroupVersionCountEntries = 1024
+
+func newGroupVersionCountCache() *lru.Cache[groupDurationCacheKey, groupVersionCountCache] {
+	// lru.New only fails on a non-positive size, which is a constant here.
+	cache, err := lru.New[groupDurationCacheKey, groupVersionCountCache](maxCachedGroupVersionCountEntries)
+	if err != nil {
+		panic(fmt.Sprintf("dbreads: invalid group version count cache size: %v", err))
+	}
+	return cache
+}
 
 type groupDurationCacheKey struct {
 	GroupID  string
@@ -451,9 +472,7 @@ func updateVersionTimeline(timeline map[time.Time]types.VersionCountMap, spans [
 func (q *Queries) GetGroupVersionCountTimeline(groupID string, duration string) (map[time.Time](types.VersionCountMap), bool, error) {
 	cacheKey := groupDurationCacheKey{GroupID: groupID, Duration: duration}
 
-	cachedGroupVersionCountLock.RLock()
-	val, ok := cachedGroupVersionCount[cacheKey]
-	cachedGroupVersionCountLock.RUnlock()
+	val, ok := cachedGroupVersionCount.Get(cacheKey)
 	if ok {
 		if time.Since(val.storedAt) < CachedGroupVersionCountLifespan {
 			l.Debug().Str("cacheStatus", "HIT").Str("groupID", groupID).Str("duration", duration).Msg("GetGroupVersionCountTimeline")
@@ -625,12 +644,12 @@ func (q *Queries) GetGroupVersionCountTimeline(groupID string, duration string) 
 	}
 
 	go func() {
-		cachedGroupVersionCountLock.Lock()
-		defer cachedGroupVersionCountLock.Unlock()
-		val, ok := cachedGroupVersionCount[cacheKey]
+		// Peek so that checking for a fresher entry doesn't itself count as a
+		// use; the Add below promotes the key when we do store something.
+		val, ok := cachedGroupVersionCount.Peek(cacheKey)
 		if !ok || time.Since(val.storedAt) >= CachedGroupVersionCountLifespan {
 			l.Debug().Str("cacheStatus", "SET").Str("groupID", groupID).Str("duration", duration).Msg("GetGroupVersionCountTimeline")
-			cachedGroupVersionCount[cacheKey] = groupVersionCountCache{timelineCount, time.Now()}
+			cachedGroupVersionCount.Add(cacheKey, groupVersionCountCache{timelineCount, time.Now()})
 		}
 	}()
 

--- a/backend/pkg/api/internal/dbreads/groups_test.go
+++ b/backend/pkg/api/internal/dbreads/groups_test.go
@@ -1,0 +1,59 @@
+package dbreads
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/types"
+)
+
+// TestGroupVersionCountCacheIsBounded checks that the version count timeline
+// cache stops growing once it is full. Entries are keyed by group ID, which is
+// caller-supplied, so an unbounded cache would let a caller iterating over
+// arbitrary group IDs grow it for the lifetime of the process.
+func TestGroupVersionCountCacheIsBounded(t *testing.T) {
+	cache := newGroupVersionCountCache()
+
+	entries := maxCachedGroupVersionCountEntries * 2
+	for i := 0; i < entries; i++ {
+		key := groupDurationCacheKey{GroupID: fmt.Sprintf("group-%d", i), Duration: "1h"}
+		cache.Add(key, groupVersionCountCache{
+			data:     map[time.Time]types.VersionCountMap{},
+			storedAt: time.Now(),
+		})
+	}
+
+	assert.Equal(t, maxCachedGroupVersionCountEntries, cache.Len(),
+		"cache grew past its bound after adding %d distinct group IDs", entries)
+}
+
+// TestGroupVersionCountCacheEvictsLeastRecentlyUsed checks that a key that
+// keeps being read survives eviction while an untouched one does not.
+func TestGroupVersionCountCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	cache := newGroupVersionCountCache()
+
+	kept := groupDurationCacheKey{GroupID: "kept", Duration: "1h"}
+	evicted := groupDurationCacheKey{GroupID: "evicted", Duration: "1h"}
+	entry := groupVersionCountCache{data: map[time.Time]types.VersionCountMap{}, storedAt: time.Now()}
+
+	cache.Add(evicted, entry)
+	cache.Add(kept, entry)
+
+	// Fill the cache, reading the key we expect to survive so it stays the
+	// most recently used one.
+	for i := 0; i < maxCachedGroupVersionCountEntries; i++ {
+		_, ok := cache.Get(kept)
+		require.True(t, ok, "kept key evicted after %d additions", i)
+		cache.Add(groupDurationCacheKey{GroupID: fmt.Sprintf("filler-%d", i), Duration: "1h"}, entry)
+	}
+
+	_, ok := cache.Get(kept)
+	assert.True(t, ok, "recently used key should have been kept")
+
+	_, ok = cache.Get(evicted)
+	assert.False(t, ok, "least recently used key should have been evicted")
+}


### PR DESCRIPTION
## Summary

* `backend/pkg/api/internal/dbreads/groups.go` cached update-history chart
  query results in a plain map keyed by group identifier and time range.
  Entries were never removed — only recomputed once stale — so every
  distinct group identifier a caller supplied, valid or not, added a
  permanent entry. Combined with the missing identifier validation covered
  in the Critical finding, this was a straightforward way to exhaust a
  Nebraska instance's memory.
* Replaced the map with a size-bounded LRU (`hashicorp/golang-lru/v2`),
  bound 1024. The dependency was already indirect in `go.mod`, now promoted
  to direct; `go.sum` unchanged, no new module fetched.
* The LRU cache is internally synchronized, so the separate
  `cachedGroupVersionCountLock` was dropped.
* The write path uses `Peek` instead of `Get`, so the freshness check
  doesn't count as a use — only an actual store promotes a key's recency.

## Bound sizing

Key space is (group × 4 durations), and each entry is small: 4/24/7/10
datapoints for 1h/1d/7d/30d respectively. 1024 entries covers roughly 256
groups.

## Relation to the identifier-validation finding

The cache read happens before duration validation, but the write is
unreachable for an invalid duration — `durationParamToPostgresTimings`
errors out first. So unbounded growth was driven purely by distinct group
identifiers, matching the report.

## Test plan

* New `groups_test.go` (first test file in this package, no DB required):
  asserts `Len()` stays at the bound after 2048 distinct group identifiers,
  and that a repeatedly-read key survives while an untouched one is evicted.
* `go build ./...`, `go vet ./...`, `gofmt` — clean
* `golangci-lint v2.9.0` (CI's version) on the package — 0 issues
* Full suite the way CI runs it (`docker compose` postgres +
  `NEBRASKA_RUN_SERVER_TESTS=1`, `go test -p 1 ./...`) — all green, including
  `pkg/api/runtime`, which exercises the existing cache HIT/STALE/SET
  behavior
* Containers torn down, linter binary removed — `git status` shows only the
  four intended files