### PR TITLE
fix(middleware): compare the Omaha endpoint secret in constant time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+
+- **Omaha endpoint secret is compared in constant time:** the secret suffix configured through `--api-endpoint-suffix` was compared with `==`, which returns as soon as it finds a differing byte. The comparison now uses `crypto/subtle.ConstantTimeCompare`, so rejection time no longer depends on how much of the suffix was correct.
+
 ### Added
 
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.

--- a/backend/pkg/middleware/omahasecret.go
+++ b/backend/pkg/middleware/omahasecret.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -12,7 +13,9 @@ func OmahaSecret(secret string) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			if strings.HasPrefix(c.Request().URL.Path, "/v1/update") {
 				pathSecret := strings.TrimPrefix(c.Request().URL.Path, "/v1/update")
-				if secret == pathSecret {
+				// Compare in constant time so that the time taken to reject a
+				// wrong suffix does not depend on how much of it was correct.
+				if subtle.ConstantTimeCompare([]byte(secret), []byte(pathSecret)) == 1 {
 					c.Request().URL.Path = "/v1/update"
 				} else {
 					return c.NoContent(http.StatusNotImplemented)

--- a/backend/pkg/middleware/omahasecret_test.go
+++ b/backend/pkg/middleware/omahasecret_test.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmahaSecret(t *testing.T) {
+	const secret = "/mysecret"
+
+	for _, tt := range []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantReached  bool
+		wantRewrites string
+	}{
+		{
+			name:         "correct secret is accepted and stripped",
+			path:         "/v1/update" + secret,
+			wantStatus:   http.StatusOK,
+			wantReached:  true,
+			wantRewrites: "/v1/update",
+		},
+		{
+			name:        "wrong secret is rejected",
+			path:        "/v1/update/wrongsecret",
+			wantStatus:  http.StatusNotImplemented,
+			wantReached: false,
+		},
+		{
+			name:        "missing secret is rejected",
+			path:        "/v1/update",
+			wantStatus:  http.StatusNotImplemented,
+			wantReached: false,
+		},
+		{
+			name:        "secret prefix is not enough",
+			path:        "/v1/update/mysec",
+			wantStatus:  http.StatusNotImplemented,
+			wantReached: false,
+		},
+		{
+			name:        "secret with trailing characters is rejected",
+			path:        "/v1/update" + secret + "extra",
+			wantStatus:  http.StatusNotImplemented,
+			wantReached: false,
+		},
+		{
+			name:        "unrelated path is passed through untouched",
+			path:        "/health",
+			wantStatus:  http.StatusOK,
+			wantReached: true,
+			// Paths outside /v1/update are not rewritten.
+			wantRewrites: "/health",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			reached := false
+			handler := OmahaSecret(secret)(func(c echo.Context) error {
+				reached = true
+				return c.NoContent(http.StatusOK)
+			})
+
+			require.NoError(t, handler(c))
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			assert.Equal(t, tt.wantReached, reached)
+			if tt.wantReached {
+				assert.Equal(t, tt.wantRewrites, c.Request().URL.Path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What's wrong**

`backend/pkg/middleware/omahasecret.go`, line 15, compares the caller-supplied
update-endpoint secret against the real one with an ordinary string
comparison. That comparison stops at the first mismatched byte. The secret
also arrives as part of the URL rather than in a header.

**Why it matters**

Early-stopping comparison means a correct prefix takes marginally longer to
reject than a wrong one, which in theory lets an attacker recover the secret
byte by byte. Over a real network this is hard to exploit reliably. The more
concrete everyday risk is the secret sitting in the URL: it ends up in proxy
logs, load-balancer logs, and browser history as a matter of course.

**Where**

`backend/pkg/middleware/omahasecret.go:15`

**How to fix it**

Swap the comparison for `crypto/subtle.ConstantTimeCompare`. Moving the
secret out of the URL and into a header is a separate, compatibility-
affecting change and should be discussed on its own before anyone takes it
on.