### PR TITLE
docs(config): roles are read from the access token, not the id token

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -130,7 +130,7 @@ func Parse() (*Config, error) {
 	f.String("oidc-issuer-url", "", "OIDC issuer URL used for authentication")
 	f.String("oidc-admin-roles", "", "comma-separated list of accepted roles with admin access")
 	f.String("oidc-viewer-roles", "", "comma-separated list of accepted roles with viewer access")
-	f.String("oidc-roles-path", "roles", "json path in which the roles array is present in the id token")
+	f.String("oidc-roles-path", "roles", "json path in which the roles array is present in the access token")
 	f.String("oidc-scopes", "openid,profile,email", "comma-separated list of scopes to be used in OIDC")
 	f.String("oidc-management-url", "", "OIDC management url for managing the account")
 	f.String("oidc-logout-url", "", "OIDC logout URL (optional fallback when end_session_endpoint is not available in discovery)")


### PR DESCRIPTION
The `--oidc-roles-path` help says the roles array is in the id token. `Authorize` applies the path to the verified access token, so the help is misleading for anyone whose provider puts roles in only one of the two.

The same wording was in the chart README and is fixed in #1618.
