### PR TITLE
fix(api): validate event previous version

### DIFF
--- a/backend/pkg/api/events_test.go
+++ b/backend/pkg/api/events_test.go
@@ -40,6 +40,9 @@ func TestRegisterEvent_InvalidParams(t *testing.T) {
 
 	_, _ = rs.GetUpdatePackage(types.Instance{ID: tInstance.ID, IP: "10.0.0.1"}, runtime.NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
 
+	err = rs.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, types.EventUpdateComplete, types.ResultSuccessReboot, "not-a-version", "")
+	assert.Equal(t, types.ErrInvalidSemver, err)
+
 	err = rs.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, 1000, types.ResultSuccess, "", "")
 	assert.Equal(t, types.ErrInvalidEventTypeOrResult, err)
 

--- a/backend/pkg/api/runtime/events.go
+++ b/backend/pkg/api/runtime/events.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"github.com/doug-martin/goqu/v9"
 
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads"
 	"github.com/flatcar/nebraska/backend/pkg/api/types"
 )
 
@@ -44,6 +45,10 @@ func (s *Service) RegisterEvent(instanceID, appID, groupID string, etype, eresul
 			}
 			return types.ErrFlatcarEventIgnored
 		}
+	}
+
+	if previousVersion != "" && previousVersion != "0.0.0.0" && !dbreads.IsValidSemver(previousVersion) {
+		return types.ErrInvalidSemver
 	}
 
 	var eventTypeID int


### PR DESCRIPTION
Fixes #1553

## Why

`RegisterEvent` could store a malformed `previousVersion` even though instance registration already validates version strings. I reproduced this on current `main` with Nebraska's real API test harness and PostgreSQL: after putting an instance into an update-in-progress state, `RegisterEvent(..., "not-a-version", ...)` returned `nil`.

## What changed

- Validate non-empty, non-`0.0.0.0` `previousVersion` values with the existing `dbreads.IsValidSemver()` helper.
- Return the existing `types.ErrInvalidSemver` before inserting the event when validation fails.
- Preserve the existing Flatcar-specific empty / `0.0.0.0` behavior.
- Add a regression case to `TestRegisterEvent_InvalidParams` that exercises `RegisterEvent` itself.

## Validation

- `go test -p 1 ./pkg/api/... -count=1` against PostgreSQL 17 — passed.
- `go build ./...` — passed.
- `./tools/check_pkg_test.sh` — passed.
- `NEBRASKA_SKIP_TESTS=1 go test ./...` — passed.
- `golangci-lint v2.12.2 run` — 0 issues.
- `git diff --check` — passed.
- `gofmt -d` on both changed Go files — no diff.

## AI assistance

I used ChatGPT to assist with codebase exploration, test planning, and review. I personally reproduced the bug, reviewed and understand every change, and ran the validation above myself.
